### PR TITLE
add option to have separate predtimechart config

### DIFF
--- a/src/hub_predtimechart/app/generate_json_files.py
+++ b/src/hub_predtimechart/app/generate_json_files.py
@@ -18,27 +18,27 @@ logger = structlog.get_logger()
 
 @click.command()
 @click.argument('hub_dir', type=click.Path(file_okay=False, exists=True))
-@click.argument('output_dir', type=click.Path(file_okay=False, exists=True))
-@click.argument('options_file', type=click.Path(file_okay=True, exists=False))
-@click.argument('conf_file', type=click.Path(file_okay=True, exists=False))
-def main(hub_dir, output_dir, options_file, conf_file):
+@click.argument('ptc_config_file', type=click.Path(file_okay=True, exists=False))
+@click.argument('options_file_out', type=click.Path(file_okay=True, exists=False))
+@click.argument('forecasts_out_dir', type=click.Path(file_okay=False, exists=True))
+def main(hub_dir, ptc_config_file, options_file_out, forecasts_out_dir):
     """
-    An app that generates predtimechart forecast json files from `hub_dir`, outputting to `output_dir`, and generates a
-    predtimechart options json file that's saved to `options_file`.
+    An app that generates the options json file and forecast json files required by
+    https://github.com/reichlab/predtimechart to visualize a hub's forecasts.
 
-    | :param hub_dir: a Path of a hub to generate forecast json files from
-    | :param output_dir: a Path to output forecast json files to
-    | :param options_file: a Path to output the predtimechart config file to
-    | :param conf_file: (optional) a Path to a `predtimechart-config.yaml` file.
-    if this is unset, it is expected to be in `hub-config/predtimechart-config.yaml`
-    as a subdirectory of `hub_dir`.
+    :param hub_dir: (input) a directory Path of a https://hubverse.io hub to generate forecast json files from
+    :param ptc_config_file: (input) a file Path to a `predtimechart-config.yaml` file that specifies how to process
+        `hub_dir` to get predtimechart output
+    :param options_file_out: (output) a file Path to output the predtimechart options object file to (see
+        https://github.com/reichlab/predtimechart?tab=readme-ov-file#options-object )
+    :param forecasts_out_dir: (output) a directory Path to output the viz forecast json files to
     """
-    logger.info(f"main({hub_dir=}, {output_dir=}): entered")
-    hub_config = HubConfig(Path(hub_dir), Path(conf_file))
-    json_files = _generate_json_files(hub_config, Path(output_dir))
-    _generate_options_file(hub_config, Path(options_file))
+    logger.info(f"main({hub_dir=}, {ptc_config_file=}, {options_file_out=}, {forecasts_out_dir=}): entered")
+    hub_config = HubConfig(Path(hub_dir), Path(ptc_config_file))
+    json_files = _generate_json_files(hub_config, Path(forecasts_out_dir))
+    _generate_options_file(hub_config, Path(options_file_out))
     logger.info(f"main(): done: {len(json_files)} JSON files generated: {[str(_) for _ in json_files]}. "
-                f"config file generated: {options_file}")
+                f"config file generated: {options_file_out}")
 
 
 #

--- a/src/hub_predtimechart/app/generate_json_files.py
+++ b/src/hub_predtimechart/app/generate_json_files.py
@@ -20,17 +20,21 @@ logger = structlog.get_logger()
 @click.argument('hub_dir', type=click.Path(file_okay=False, exists=True))
 @click.argument('output_dir', type=click.Path(file_okay=False, exists=True))
 @click.argument('options_file', type=click.Path(file_okay=True, exists=False))
-def main(hub_dir, output_dir, options_file):
+@click.argument('conf_file', type=click.Path(file_okay=True, exists=False))
+def main(hub_dir, output_dir, options_file, conf_file):
     """
     An app that generates predtimechart forecast json files from `hub_dir`, outputting to `output_dir`, and generates a
     predtimechart options json file that's saved to `options_file`.
 
-    :param hub_dir: a Path of a hub to generate forecast json files from
-    :param output_dir: a Path to output forecast json files to
-    :param options_file: a Path to output the predtimechart config file to
+    | :param hub_dir: a Path of a hub to generate forecast json files from
+    | :param output_dir: a Path to output forecast json files to
+    | :param options_file: a Path to output the predtimechart config file to
+    | :param conf_file: (optional) a Path to a `predtimechart-config.yaml` file.
+    if this is unset, it is expected to be in `hub-config/predtimechart-config.yaml`
+    as a subdirectory of `hub_dir`.
     """
     logger.info(f"main({hub_dir=}, {output_dir=}): entered")
-    hub_config = HubConfig(Path(hub_dir))
+    hub_config = HubConfig(Path(hub_dir), Path(conf_file))
     json_files = _generate_json_files(hub_config, Path(output_dir))
     _generate_options_file(hub_config, Path(options_file))
     logger.info(f"main(): done: {len(json_files)} JSON files generated: {[str(_) for _ in json_files]}. "

--- a/src/hub_predtimechart/hub_config.py
+++ b/src/hub_predtimechart/hub_config.py
@@ -17,7 +17,7 @@ class HubConfig:
     """
 
 
-    def __init__(self, hub_dir: Path):
+    def __init__(self, hub_dir: Path, conf_file: None):
         """
         :param hub_dir: Path to a hub's root directory. see: https://hubverse.io/en/latest/user-guide/hub-structure.html
         """
@@ -30,7 +30,10 @@ class HubConfig:
         self.hub_dir = hub_dir
 
         # check for predtimechart config file
-        ptc_config_file = self.hub_dir / 'hub-config' / 'predtimechart-config.yml'
+        if conf_file is not None:
+            ptc_config_file = conf_file
+        else:
+            ptc_config_file = self.hub_dir / 'hub-config' / 'predtimechart-config.yml'
         if not ptc_config_file.exists():
             raise RuntimeError(f"predtimechart config file not found: {ptc_config_file}")
 

--- a/src/hub_predtimechart/hub_config.py
+++ b/src/hub_predtimechart/hub_config.py
@@ -17,9 +17,11 @@ class HubConfig:
     """
 
 
-    def __init__(self, hub_dir: Path, conf_file: None):
+    def __init__(self, hub_dir: Path, ptc_config_file: Path):
         """
         :param hub_dir: Path to a hub's root directory. see: https://hubverse.io/en/latest/user-guide/hub-structure.html
+        :param ptc_config_file: (input) a file Path to a `predtimechart-config.yaml` file that specifies how to process
+            `hub_dir` to get predtimechart output
         """
         super().__init__()
 
@@ -30,10 +32,6 @@ class HubConfig:
         self.hub_dir = hub_dir
 
         # check for predtimechart config file
-        if conf_file is not None:
-            ptc_config_file = conf_file
-        else:
-            ptc_config_file = self.hub_dir / 'hub-config' / 'predtimechart-config.yml'
         if not ptc_config_file.exists():
             raise RuntimeError(f"predtimechart config file not found: {ptc_config_file}")
 
@@ -43,7 +41,7 @@ class HubConfig:
             try:
                 _validate_predtimechart_config(ptc_config)
             except ValidationError as ve:
-                raise RuntimeError(f"invalid predtimechart-config.yml. error='{ve}'")
+                raise RuntimeError(f"invalid ptc_config_file. error='{ve}'")
 
             self.rounds_idx = ptc_config['rounds_idx']
             self.model_tasks_idx = ptc_config['model_tasks_idx']
@@ -55,8 +53,8 @@ class HubConfig:
 
         # set model_ids
         self.model_id_to_metadata = {}
-        for model_metadata_file in (list((hub_dir / 'model-metadata').glob('*.yml')) +
-                                    list((hub_dir / 'model-metadata').glob('*.yaml'))):
+        for model_metadata_file in (list((self.hub_dir / 'model-metadata').glob('*.yml')) +
+                                    list((self.hub_dir / 'model-metadata').glob('*.yaml'))):
             with open(model_metadata_file, 'r') as fp:
                 model_metadata = yaml.safe_load(fp)
                 model_id = f"{model_metadata['team_abbr']}-{model_metadata['model_abbr']}"

--- a/tests/hub_predtimechart/test_generate_data.py
+++ b/tests/hub_predtimechart/test_generate_data.py
@@ -20,7 +20,7 @@ def test_json_file_name():
 
 def test_forecast_data_for_model_df_complex_forecast_hub_US():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir=hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     with open('tests/expected/example-complex-forecast-hub/forecasts/wk-inc-flu-hosp_US_2022-10-22.json') as fp:
         exp_data = json.load(fp)
@@ -45,7 +45,7 @@ def test_forecast_data_for_model_df_complex_forecast_hub_US():
 
 def test_forecast_data_for_model_df_complex_forecast_hub_01():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir=hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     with open('tests/expected/example-complex-forecast-hub/forecasts/wk-inc-flu-hosp_01_2022-10-22.json') as fp:
         exp_data = json.load(fp)
@@ -70,7 +70,7 @@ def test_forecast_data_for_model_df_complex_forecast_hub_01():
 
 def test_forecast_data_for_model_df_no_data():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir=hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     model_output_file = hub_dir / 'model-output/Flusight-baseline/2022-10-22-Flusight-baseline.csv'
     act_data = forecast_data_for_model_df(hub_config, pd.read_csv(model_output_file), 'wk inc flu hosp', ('01',))

--- a/tests/hub_predtimechart/test_generate_json_files.py
+++ b/tests/hub_predtimechart/test_generate_json_files.py
@@ -11,7 +11,7 @@ def test_generate_json_files(tmp_path):
     An integration test of `generate_json_files.py`'s `_generate_json_files()`.
     """
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir=hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     output_dir = tmp_path
     json_files = _generate_json_files(hub_config, output_dir)
     assert set(json_files) == {output_dir / 'wk-inc-flu-hosp_US_2022-10-22.json',
@@ -33,7 +33,7 @@ def test_generate_options_file(tmp_path):
     An integration test of `generate_json_files.py`'s `_generate_options_file()`.
     """
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir=hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     ptc_options = tmp_path / 'ptc_options'
     _generate_options_file(hub_config, ptc_options)
     with open(ptc_options) as act_options_fp, \

--- a/tests/hub_predtimechart/test_generate_options.py
+++ b/tests/hub_predtimechart/test_generate_options.py
@@ -7,7 +7,7 @@ from hub_predtimechart.hub_config import HubConfig
 
 def test_generate_options_complex_forecast_hub():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir=hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     with open('tests/expected/example-complex-forecast-hub/predtimechart-options.json') as fp:
         exp_options = json.load(fp)
     act_options = ptc_options_for_hub(hub_config)

--- a/tests/hub_predtimechart/test_hub_config.py
+++ b/tests/hub_predtimechart/test_hub_config.py
@@ -11,7 +11,7 @@ from hub_predtimechart.hub_config import HubConfig, _validate_predtimechart_conf
 
 def test_hub_config_complex_forecast_hub():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     assert hub_config.hub_dir == hub_dir
     assert hub_config.rounds_idx == 0  # 'rounds'[0]
     assert hub_config.model_tasks_idx == 2  # 'rounds'[0]['model_tasks'][2]
@@ -48,7 +48,7 @@ def test_hub_config_complex_forecast_hub():
 
 def test_hub_config_complex_scenario_hub():
     hub_dir = Path('tests/hubs/example-complex-scenario-hub')
-    hub_config = HubConfig(hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     assert hub_config.hub_dir == hub_dir
     assert hub_config.rounds_idx == 1  # 'rounds'[1]
@@ -128,7 +128,7 @@ def test_hub_config_complex_scenario_hub():
 
 def test_model_output_file_for_ref_date():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir)
+    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     # case: exists
     file = hub_config.model_output_file_for_ref_date('Flusight-baseline', "2022-10-22")
@@ -148,13 +148,13 @@ def test_model_output_file_for_ref_date():
 def test_hub_dir_existence():
     with pytest.raises(RuntimeError, match="hub_dir not found"):
         hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-        HubConfig(hub_dir / 'bad-dir')
+        HubConfig(hub_dir / 'nonexistent-dir', None)
 
 
 def test_predtimechart_config_file_existence():
     with pytest.raises(RuntimeError, match="predtimechart config file not found"):
         hub_dir = Path('tests/hubs/no-ptc-config-hub')
-        HubConfig(hub_dir)
+        HubConfig(hub_dir, hub_dir / 'nonexistent-file.yml')
 
 
 def test_predtimechart_config_file_validity():
@@ -163,12 +163,14 @@ def test_predtimechart_config_file_validity():
     checked elsewhere
     """
     # test a known invalid hub
-    with pytest.raises(RuntimeError, match="invalid predtimechart-config.yml"):
-        HubConfig(Path('tests/hubs/invalid-ptc-config-hub'))
+    with pytest.raises(RuntimeError, match="invalid ptc_config_file"):
+        hub_dir = Path('tests/hubs/invalid-ptc-config-hub')
+        HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     # test that HubConfig() calls `_validate_predtimechart_config()`, and then test against that function directly
     with patch('hub_predtimechart.hub_config._validate_predtimechart_config') as validate_mock:
-        HubConfig(Path('tests/hubs/example-complex-forecast-hub'))
+        hub_dir = Path('tests/hubs/example-complex-forecast-hub')
+        HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
         validate_mock.assert_called_once()
 
     # get a valid config file to work with and then invalidate it in a few different ways to make sure schema.json is in
@@ -194,8 +196,8 @@ def test_hub_dir_ptc_compatibility():
     # constraints: see README.MD > Assumptions/limitations
     with pytest.raises(RuntimeError, match="hub is incompatible with predtimechart"):
         hub_dir = Path('tests/hubs/example-complex-scenario-hub')
-        HubConfig(hub_dir)
+        HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     with pytest.raises(RuntimeError, match="hub is incompatible with predtimechart"):
         hub_dir = Path('tests/hubs/no-ptc-config-hub')
-        HubConfig(hub_dir)
+        HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')


### PR DESCRIPTION
At the moment, it's assumed that the configuration for predtimechart
always lives in the hub under `hub-config/predtimechart-config.yml`.

This change proposes an _optional argument_ that allows the user to
specify the path to this config file so the following scenarios could be
achieved:

 - a 4-letter extension `hub-config/predtimechart-config.yaml`
 - a hiddent file called `hub-config/.predtimechart-config.yml`
 - a file in a different repository so that the dashboard configuration
   can be completely separate from the hub workings

NOTE: I _do not_ know how click works and I do not know how to create an
optional argument (most python people look down upon us lowly R folk and
tut tut about our weakly-typed functions, to which I say: fair enough).

This will _likely fail_ because of my lack of knowledge of python
workings. I am hoping that you can help me with that. 
