### PR TITLE
add click dependency to pyproject.tom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## hub-dashboard-predtimechart
+# hub-dashboard-predtimechart
 
-## Goal
+# Goal
 
 Create an initial dashboard that provides a [predtimechart](https://github.com/reichlab/predtimechart)-based forecast visualization component for the hub. The thinking is that this will allow us to get something practical into the hands of hubverse users relatively quickly.
 
@@ -9,7 +9,7 @@ Considerations:
 - Client side only, i.e., nothing server-side. This will greatly simplify new hub onboarding.
 - Others: @todo
 
-## Python application
+# Python application
 
 A python application to create predtimechart JSON files is available from this
 repository and can be installed in a fresh python environment via pip:
@@ -24,7 +24,7 @@ The application can then be run from the command line:
 hub_predtimechart --help
 ```
 
-## Implementation summary
+# Implementation summary
 
 The major parts of this project are:
 
@@ -37,7 +37,7 @@ The major parts of this project are:
     - generation details (reference_date -> as_of/selected date, horizon, target_date: x axis, task id vars -> dropdowns, ...): @todo
 4. **Server/Dashboard**: We will write a simple dashboard page providing a link to the forecast visualization (predtimechart) page. Our initial thought is to implement this via a straighforward [S3 static website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html) (i.e., a self-contained `index.html` file, perhaps with some JavaScript to access basic [hubverse admin](https://hubverse.io/en/latest/quickstart-hub-admin/intro.html) information to orient the viewer such as hub name, tasks summary, etc.) Two comparable sites are https://respicast.ecdc.europa.eu/ (especially) and https://covid19forecasthub.org/ . See [Dashboard architecture] below for details.
 
-### Assumptions/limitations
+## Assumptions/limitations
 
 Initially the visualization will have these limitations:
 
@@ -53,7 +53,7 @@ Initially the visualization will have these limitations:
 - The `initial_as_of` and `current_date` config fields are the last of `hub_config.fetch_reference_dates`.
 - The `initial_task_ids` config field is the first `task_ids` `value`.
 
-## Required hub configuration
+# Required hub configuration
 
 Some visualization-related information must be configured for each hub, including:
 
@@ -66,7 +66,7 @@ Some visualization-related information must be configured for each hub, includin
 - `initial_checked_models` (a predtimechart option)
 - others: @todo
 
-## Dashboard architecture
+# Dashboard architecture
 
 Our initial thinking is an approach where we provide a fixed layout (e.g., a menubar at top and a content area in the middle, such as found at https://respicast.ecdc.europa.eu/ ) that allows limited customization [specified by convention](https://en.wikipedia.org/wiki/Convention_over_configuration) via markdown files (some with specific names) placed in directories with specific names. Details:
 
@@ -79,11 +79,11 @@ Our initial thinking is an approach where we provide a fixed layout (e.g., a men
     - "Evaluations": @todo
     - "Background", "Community", "Get in touch": @todo loaded from specific files under `hub-website` such as `background.md`, etc.
 
-## Testing
+# Testing
 
 We plan to primarily use https://github.com/hubverse-org/example-complex-forecast-hub for development unit tests.
 
-## Questions/issues
+# Questions/issues
 
 - How/when will file generation be triggered? This applies to both `.json` visualization files and the predtimechart configuration object. For example, and admin UI, GitHub Action on schedule, round close, etc.
 - Is this a good time to remove predtimechart's user ensemble, if desired?
@@ -97,11 +97,11 @@ We plan to primarily use https://github.com/hubverse-org/example-complex-forecas
 - Should we filter out `hub_config.horizon_col_name == 0` ?
 - Should `forecast_data_for_model_df()`'s `quantile_levels` be stored in a config file somewhere?
 
-## Python local dev setup
+# Python local dev setup
 
 Use the following to create a local dev setup using pyenv and pipenv, which we assume are already installed.
 
-### Set up the virtual environment
+## Set up the virtual environment
 
 ```bash
 $ cd <this repo>
@@ -109,21 +109,21 @@ $ pyenv versions  # you should see this repo's .python-version set
 $ pipenv --python $(pyenv which python)
 ```
 
-### Generate requirements-dev.txt (for pipenv, etc.)
+## Generate requirements-dev.txt (for pipenv, etc.)
 
 ```bash
 $ pipenv install pip-tools  # for `pip-compile`
 $ pipenv run pip-compile --extra=dev --output-file=requirements/requirements.txt pyproject.toml
 ```
 
-### Install required packages
+## Install required packages
 
 ```bash
 $ cd <this repo>
 $ pipenv install -r requirements/requirements.txt -e .
 ```
 
-### Run the tests and application
+## Run the tests and application
 
 ```bash
 $ cd <this repo>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# hub-dashboard-predtimechart
+## hub-dashboard-predtimechart
 
-# Goal
+## Goal
 
 Create an initial dashboard that provides a [predtimechart](https://github.com/reichlab/predtimechart)-based forecast visualization component for the hub. The thinking is that this will allow us to get something practical into the hands of hubverse users relatively quickly.
 
@@ -9,7 +9,22 @@ Considerations:
 - Client side only, i.e., nothing server-side. This will greatly simplify new hub onboarding.
 - Others: @todo
 
-# Implementation summary
+## Python application
+
+A python application to create predtimechart JSON files is available from this
+repository and can be installed in a fresh python environment via pip:
+
+```sh
+pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
+```
+
+The application can then be run from the command line:
+
+```sh
+hub_predtimechart --help
+```
+
+## Implementation summary
 
 The major parts of this project are:
 
@@ -22,7 +37,7 @@ The major parts of this project are:
     - generation details (reference_date -> as_of/selected date, horizon, target_date: x axis, task id vars -> dropdowns, ...): @todo
 4. **Server/Dashboard**: We will write a simple dashboard page providing a link to the forecast visualization (predtimechart) page. Our initial thought is to implement this via a straighforward [S3 static website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html) (i.e., a self-contained `index.html` file, perhaps with some JavaScript to access basic [hubverse admin](https://hubverse.io/en/latest/quickstart-hub-admin/intro.html) information to orient the viewer such as hub name, tasks summary, etc.) Two comparable sites are https://respicast.ecdc.europa.eu/ (especially) and https://covid19forecasthub.org/ . See [Dashboard architecture] below for details.
 
-# Assumptions/limitations
+### Assumptions/limitations
 
 Initially the visualization will have these limitations:
 
@@ -38,7 +53,7 @@ Initially the visualization will have these limitations:
 - The `initial_as_of` and `current_date` config fields are the last of `hub_config.fetch_reference_dates`.
 - The `initial_task_ids` config field is the first `task_ids` `value`.
 
-# Required hub configuration
+## Required hub configuration
 
 Some visualization-related information must be configured for each hub, including:
 
@@ -51,7 +66,7 @@ Some visualization-related information must be configured for each hub, includin
 - `initial_checked_models` (a predtimechart option)
 - others: @todo
 
-# Dashboard architecture
+## Dashboard architecture
 
 Our initial thinking is an approach where we provide a fixed layout (e.g., a menubar at top and a content area in the middle, such as found at https://respicast.ecdc.europa.eu/ ) that allows limited customization [specified by convention](https://en.wikipedia.org/wiki/Convention_over_configuration) via markdown files (some with specific names) placed in directories with specific names. Details:
 
@@ -64,11 +79,11 @@ Our initial thinking is an approach where we provide a fixed layout (e.g., a men
     - "Evaluations": @todo
     - "Background", "Community", "Get in touch": @todo loaded from specific files under `hub-website` such as `background.md`, etc.
 
-# Testing
+## Testing
 
 We plan to primarily use https://github.com/hubverse-org/example-complex-forecast-hub for development unit tests.
 
-# Questions/issues
+## Questions/issues
 
 - How/when will file generation be triggered? This applies to both `.json` visualization files and the predtimechart configuration object. For example, and admin UI, GitHub Action on schedule, round close, etc.
 - Is this a good time to remove predtimechart's user ensemble, if desired?
@@ -82,11 +97,11 @@ We plan to primarily use https://github.com/hubverse-org/example-complex-forecas
 - Should we filter out `hub_config.horizon_col_name == 0` ?
 - Should `forecast_data_for_model_df()`'s `quantile_levels` be stored in a config file somewhere?
 
-# Python local dev setup
+## Python local dev setup
 
 Use the following to create a local dev setup using pyenv and pipenv, which we assume are already installed.
 
-## Set up the virtual environment
+### Set up the virtual environment
 
 ```bash
 $ cd <this repo>
@@ -94,21 +109,21 @@ $ pyenv versions  # you should see this repo's .python-version set
 $ pipenv --python $(pyenv which python)
 ```
 
-## Generate requirements-dev.txt (for pipenv, etc.)
+### Generate requirements-dev.txt (for pipenv, etc.)
 
 ```bash
 $ pipenv install pip-tools  # for `pip-compile`
 $ pipenv run pip-compile --extra=dev --output-file=requirements/requirements.txt pyproject.toml
 ```
 
-## Install required packages
+### Install required packages
 
 ```bash
 $ cd <this repo>
 $ pipenv install -r requirements/requirements.txt -e .
 ```
 
-## Run the tests and application
+### Run the tests and application
 
 ```bash
 $ cd <this repo>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The major parts of this project are:
     - generation details (reference_date -> as_of/selected date, horizon, target_date: x axis, task id vars -> dropdowns, ...): @todo
 4. **Server/Dashboard**: We will write a simple dashboard page providing a link to the forecast visualization (predtimechart) page. Our initial thought is to implement this via a straighforward [S3 static website](https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html) (i.e., a self-contained `index.html` file, perhaps with some JavaScript to access basic [hubverse admin](https://hubverse.io/en/latest/quickstart-hub-admin/intro.html) information to orient the viewer such as hub name, tasks summary, etc.) Two comparable sites are https://respicast.ecdc.europa.eu/ (especially) and https://covid19forecasthub.org/ . See [Dashboard architecture] below for details.
 
-## Assumptions/limitations
+# Assumptions/limitations
 
 Initially the visualization will have these limitations:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
+    "click",
     "pandas",
     "pyyaml",
     "structlog",


### PR DESCRIPTION
This will fix #13 by 

1. ensuring that this can be installed via `pip install git+` and 
2. updating the README to include instructions to run the project.

Additionally, I have updated the README headings to follow WCAG Guidelines to only have one `<h1>` heading. See: [the WCAG guide H42: Using h1-h6 to identify headings](https://www.w3.org/TR/WCAG20-TECHS/G141) and https://webaim.org/techniques/headings/


## Example of changes

```
(znk/fix-requirements/13)$ tmp=$(mktemp -d) && cd $tmp && python -m venv .venv && source .venv/bin/activate
11:53:48 /var/folders/9p/m996p3_55hjf1hc62552cqfr0000gr/T/tmp.JSMQagFiLX
$ pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart/@znk/fix-requirements/13
```

<details>
<summary>Installation garbage</summary>

```
Collecting git+https://github.com/hubverse-org/hub-dashboard-predtimechart/@znk/fix-requirements/13
  Cloning https://github.com/hubverse-org/hub-dashboard-predtimechart/ (to revision znk/fix-requirements/13) to /private/var/folders/9p/m996p3_55hjf1hc62552cqfr0000gr/T/pip-req-build-i4vsi70g
  Running command git clone --filter=blob:none --quiet https://github.com/hubverse-org/hub-dashboard-predtimechart/ /private/var/folders/9p/m996p3_55hjf1hc62552cqfr0000gr/T/pip-req-build-i4vsi70g
  Running command git checkout -b znk/fix-requirements/13 --track origin/znk/fix-requirements/13
  Switched to a new branch 'znk/fix-requirements/13'
  branch 'znk/fix-requirements/13' set up to track 'origin/znk/fix-requirements/13'.
  Resolved https://github.com/hubverse-org/hub-dashboard-predtimechart/ to commit 46e5ab9bc3e4ec8a8fac26f776cbd06e63f49b51
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting click (from hub-dashboard-predtimechart==0.0.1)
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Collecting pandas (from hub-dashboard-predtimechart==0.0.1)
  Using cached pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl.metadata (89 kB)
Collecting pyyaml (from hub-dashboard-predtimechart==0.0.1)
  Using cached PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (2.1 kB)
Collecting structlog (from hub-dashboard-predtimechart==0.0.1)
  Using cached structlog-24.4.0-py3-none-any.whl.metadata (7.3 kB)
Collecting pyarrow (from hub-dashboard-predtimechart==0.0.1)
  Using cached pyarrow-17.0.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (3.3 kB)
Collecting jsonschema (from hub-dashboard-predtimechart==0.0.1)
  Using cached jsonschema-4.23.0-py3-none-any.whl.metadata (7.9 kB)
Collecting attrs>=22.2.0 (from jsonschema->hub-dashboard-predtimechart==0.0.1)
  Using cached attrs-24.2.0-py3-none-any.whl.metadata (11 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema->hub-dashboard-predtimechart==0.0.1)
  Using cached jsonschema_specifications-2023.12.1-py3-none-any.whl.metadata (3.0 kB)
Collecting referencing>=0.28.4 (from jsonschema->hub-dashboard-predtimechart==0.0.1)
  Using cached referencing-0.35.1-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema->hub-dashboard-predtimechart==0.0.1)
  Using cached rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (4.2 kB)
Collecting numpy>=1.26.0 (from pandas->hub-dashboard-predtimechart==0.0.1)
  Using cached numpy-2.1.1-cp312-cp312-macosx_14_0_arm64.whl.metadata (60 kB)
Collecting python-dateutil>=2.8.2 (from pandas->hub-dashboard-predtimechart==0.0.1)
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting pytz>=2020.1 (from pandas->hub-dashboard-predtimechart==0.0.1)
  Using cached pytz-2024.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting tzdata>=2022.7 (from pandas->hub-dashboard-predtimechart==0.0.1)
  Using cached tzdata-2024.2-py2.py3-none-any.whl.metadata (1.4 kB)
Collecting six>=1.5 (from python-dateutil>=2.8.2->pandas->hub-dashboard-predtimechart==0.0.1)
  Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
Using cached click-8.1.7-py3-none-any.whl (97 kB)
Using cached jsonschema-4.23.0-py3-none-any.whl (88 kB)
Using cached pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl (11.4 MB)
Using cached pyarrow-17.0.0-cp312-cp312-macosx_11_0_arm64.whl (27.2 MB)
Using cached PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl (173 kB)
Using cached structlog-24.4.0-py3-none-any.whl (67 kB)
Using cached attrs-24.2.0-py3-none-any.whl (63 kB)
Using cached jsonschema_specifications-2023.12.1-py3-none-any.whl (18 kB)
Using cached numpy-2.1.1-cp312-cp312-macosx_14_0_arm64.whl (5.1 MB)
Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Using cached pytz-2024.2-py2.py3-none-any.whl (508 kB)
Using cached referencing-0.35.1-py3-none-any.whl (26 kB)
Using cached rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl (313 kB)
Using cached tzdata-2024.2-py2.py3-none-any.whl (346 kB)
Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Building wheels for collected packages: hub-dashboard-predtimechart
  Building wheel for hub-dashboard-predtimechart (pyproject.toml) ... done
  Created wheel for hub-dashboard-predtimechart: filename=hub_dashboard_predtimechart-0.0.1-py3-none-any.whl size=15308 sha256=464d6c28afe0c23d10515a3fd583e168ac5de358f7b14849fc193135d178b35f
  Stored in directory: /private/var/folders/9p/m996p3_55hjf1hc62552cqfr0000gr/T/pip-ephem-wheel-cache-r5o741nf/wheels/1d/5c/9d/39761b6c89e6a0bf01086d8dfdad220a16865d7dfbfc55024e
```

</details>

```
Successfully built hub-dashboard-predtimechart
Installing collected packages: pytz, tzdata, structlog, six, rpds-py, pyyaml, numpy, click, attrs, referencing, python-dateutil, pyarrow, pandas, jsonschema-specifications, jsonschema, hub-dashboard-predtimechart
Successfully installed attrs-24.2.0 click-8.1.7 hub-dashboard-predtimechart-0.0.1 jsonschema-4.23.0 jsonschema-specifications-2023.12.1 numpy-2.1.1 pandas-2.2.3 pyarrow-17.0.0 python-dateutil-2.9.0.post0 pytz-2024.2 pyyaml-6.0.2 referencing-0.35.1 rpds-py-0.20.0 six-1.16.0 structlog-24.4.0 tzdata-2024.2
```

Click appears to be installed and I can run it: 

```
11:54:09 /var/folders/9p/m996p3_55hjf1hc62552cqfr0000gr/T/tmp.JSMQagFiLX
$ hub_predtimechart --help
Usage: hub_predtimechart [OPTIONS] HUB_DIR PTC_CONFIG_FILE OPTIONS_FILE_OUT
                         FORECASTS_OUT_DIR

  Generates the options json file and forecast json files used by
  https://github.com/reichlab/predtimechart to visualize a hub's forecasts.

  HUB_DIR: (input) a directory Path of a https://hubverse.io hub to generate
  forecast json files from

  PTC_CONFIG_FILE: (input) a file Path to a `predtimechart-config.yaml` file
  that specifies how to process `hub_dir` to get predtimechart output

  OPTIONS_FILE_OUT: (output) a file Path to output the predtimechart options
  object file to (see https://github.com/reichlab/predtimechart?tab=readme-ov-
  file#options-object )

  FORECASTS_OUT_DIR: (output) a directory Path to output the viz forecast json
  files to

Options:
  --help  Show this message and exit.
```
