### PR TITLE
add project entry points for new function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 [project.entry-points."console_scripts"]
 hub_predtimechart = "hub_predtimechart.app.generate_json_files:main"
 ptc_generate_json_files = "hub_predtimechart.app.generate_json_files:main"
-ptc_generate_FluSight_targets = "hub_predtimechart.app.generate_target_json_files_FluSight:main"
+ptc_generate_flusight_targets = "hub_predtimechart.app.generate_target_json_files_FluSight:main"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dev = [
 
 [project.entry-points."console_scripts"]
 hub_predtimechart = "hub_predtimechart.app.generate_json_files:main"
+ptc_generate_json_files = "hub_predtimechart.app.generate_json_files:main"
+ptc_generate_FluSight_targets = "hub_predtimechart.app.generate_target_json_files_FluSight:main"
+
 
 [build-system]
 # Minimum requirements for the build system to execute.


### PR DESCRIPTION
I've done the following:

1. added an alias to the `hub_predtimechart` function called "ptc_generate_json_files", so that it's more clear what is happening
2. added `ptc_generate_FluSight_targets` to point to `generate_target_json_files_FluSight.py`

I'm fairly confident this should work based on [the setup tools page on entry points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins):


> Our plugin could have also defined multiple entry points under the group ``timmins.display``.
> For example, in ``src/timmins_plugin_fancy/__init__.py`` we could have two ``display()``-like
> functions, as follows:
> 
> ```python
> def excl_display(text):
>     print('!!!', text, '!!!')
> 
> def lined_display(text):
>     print(''.join(['-' for _ in text]))
>     print(text)
>     print(''.join(['-' for _ in text]))
> ```
> 
> The configuration of ``timmins-plugin-fancy`` would then change to:
> 
> `pyproject.toml`
> 
> ```toml
> [project.entry-points."timmins.display"]
> excl = "timmins_plugin_fancy:excl_display"
> lined = "timmins_plugin_fancy:lined_display"
> ```