### PR TITLE
remove "disclaimer" from code and files, fix failing test

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,7 @@
 </div>
 
 <script type="module">
-    import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@2.0.10/dist/predtimechart.bundle.js';
+    import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@2.0.11/dist/predtimechart.bundle.js';
     document.predtimechart = App;  // for debugging
 
     function replace_chars(the_string) {

--- a/demo/predtimechart-options.json
+++ b/demo/predtimechart-options.json
@@ -74,6 +74,5 @@
     "current_date": "2023-05-27",
     "models": ["Flusight-baseline", "MOBS-GLEAM_FLUH", "PSI-DICE"],
     "initial_checked_models": ["Flusight-baseline"],
-    "disclaimer": "Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends.",
     "initial_xaxis_range": null
 }

--- a/src/hub_predtimechart/app/generate_target_json_files_FluSight.py
+++ b/src/hub_predtimechart/app/generate_target_json_files_FluSight.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime, timedelta
 import json
-import re
 from pathlib import Path
 
 import click
@@ -56,11 +55,13 @@ def main(hub_dir, target_out_dir):
     logger.info(f'main(): done: {len(json_files)} JSON files generated: {[str(_) for _ in json_files]}. ')
     
 
-
 #
 # _generate_json_files() and helpers
 #
-def reference_date_from_today(now: datetime = date.today()) -> datetime:
+def reference_date_from_today(now: date = None) -> date:
+    if now is None:  # per https://stackoverflow.com/questions/52511405/freeze-time-not-working-for-default-param
+        now = date.today()
+
     # Calculate the days until the next Saturday
     days_to_saturday = 5 - now.weekday()
     if days_to_saturday < 0:

--- a/src/hub_predtimechart/generate_options.py
+++ b/src/hub_predtimechart/generate_options.py
@@ -39,9 +39,6 @@ def ptc_options_for_hub(hub_config: HubConfig):
     options['models'].sort()
     options['initial_checked_models'] = hub_config.initial_checked_models
 
-    # set `disclaimer`
-    options['disclaimer'] = hub_config.disclaimer
-
     # set `initial_xaxis_range`
     options['initial_xaxis_range'] = None
 

--- a/src/hub_predtimechart/hub_config.py
+++ b/src/hub_predtimechart/hub_config.py
@@ -58,7 +58,6 @@ class HubConfig:
         self.target_date_col_name = ptc_config['target_date_col_name']
         self.horizon_col_name = ptc_config['horizon_col_name']
         self.initial_checked_models = ptc_config['initial_checked_models']
-        self.disclaimer = ptc_config['disclaimer']
 
         # set model_ids
         self.model_id_to_metadata = {}

--- a/src/hub_predtimechart/ptc_schema.py
+++ b/src/hub_predtimechart/ptc_schema.py
@@ -38,11 +38,6 @@ ptc_config_schema = {
             "items": {
                 "type": "string"
             }
-        },
-        "disclaimer": {
-            "description": "text providing any important information users should know",
-            "type": "string",
-            "minLength": 1
         }
     },
     "required": [
@@ -51,7 +46,6 @@ ptc_config_schema = {
         "reference_date_col_name",
         "target_date_col_name",
         "horizon_col_name",
-        "initial_checked_models",
-        "disclaimer"
+        "initial_checked_models"
     ]
 }

--- a/tests/expected/FluSight-forecast-hub/predtimechart-options.json
+++ b/tests/expected/FluSight-forecast-hub/predtimechart-options.json
@@ -76,6 +76,5 @@
     "CADPH-FluCAT_Ensemble", "CEPH-Rtrend_fluH", "CMU-TimeSeries", "CU-ensemble", "GT-FluFNP", "ISU_NiemiLab-NLH", "JHU_CSSE-CSSE_Ensemble", "LUcompUncertLab-chimera", "LosAlamos_NAU-CModel_Flu", "MIGHTE-Nsemble", "MOBS-GLEAM_FLUH", "NIH-Flu_ARIMA", "NU_UCSD-GLEAM_AI_FLUH", "PSI-PROF", "SGroup-RandomForest", "SigSci-CREG", "SigSci-TSENS", "Stevens-GBR", "UGA_flucast-Copycat", "UGA_flucast-INFLAenza", "UGuelph-CompositeCurve", "UGuelphensemble-GRYPHON", "UM-DeepOutbreak", "UMass-flusion", "UMass-trends_ensemble", "UNC_IDD-InfluPaint", "UVAFluX-Ensemble", "VTSanghani-Ensemble", "cfa-flumech", "cfarenewal-cfaepimlight", "fjordhest-ensemble"
   ],
   "initial_checked_models": ["UMass-flusion", "UMass-trends_ensemble"],
-  "disclaimer": "Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends.",
   "initial_xaxis_range": null
 }

--- a/tests/expected/example-complex-forecast-hub/predtimechart-options.json
+++ b/tests/expected/example-complex-forecast-hub/predtimechart-options.json
@@ -74,6 +74,5 @@
   "current_date": "2023-05-27",
   "models": ["Flusight-baseline", "MOBS-GLEAM_FLUH", "PSI-DICE"],
   "initial_checked_models": ["Flusight-baseline"],
-  "disclaimer": "Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends.",
   "initial_xaxis_range": null
 }

--- a/tests/hub_predtimechart/test_generate_options.py
+++ b/tests/hub_predtimechart/test_generate_options.py
@@ -13,7 +13,7 @@ def test_generate_options_complex_forecast_hub():
     act_options = ptc_options_for_hub(hub_config)
     for exp_field in ['target_variables', 'initial_target_var', 'task_ids', 'initial_task_ids', 'intervals',
                       'initial_interval', 'available_as_ofs', 'initial_as_of', 'current_date', 'models',
-                      'initial_checked_models', 'disclaimer', 'initial_xaxis_range']:
+                      'initial_checked_models', 'initial_xaxis_range']:
         assert exp_field in act_options
         assert act_options[exp_field] == exp_options[exp_field]
 

--- a/tests/hub_predtimechart/test_hub_config.py
+++ b/tests/hub_predtimechart/test_hub_config.py
@@ -20,7 +20,6 @@ def test_hub_config_complex_forecast_hub():
     assert hub_config.target_date_col_name == 'target_end_date'
     assert hub_config.horizon_col_name == 'horizon'
     assert hub_config.initial_checked_models == ['Flusight-baseline']
-    assert hub_config.disclaimer == "Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends."
     assert (sorted(list(hub_config.model_id_to_metadata.keys())) ==
             sorted(['Flusight-baseline', 'MOBS-GLEAM_FLUH', 'PSI-DICE']))
     assert hub_config.task_ids == sorted(['reference_date', 'target', 'horizon', 'location', 'target_end_date'])

--- a/tests/hubs/FluSight-forecast-hub/hub-config/predtimechart-config.yml
+++ b/tests/hubs/FluSight-forecast-hub/hub-config/predtimechart-config.yml
@@ -5,4 +5,3 @@ reference_date_col_name: 'reference_date'
 target_date_col_name: 'target_end_date'
 horizon_col_name: 'horizon'
 initial_checked_models: ['UMass-flusion', 'UMass-trends_ensemble']
-disclaimer: Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends.

--- a/tests/hubs/example-complex-forecast-hub/hub-config/predtimechart-config.yml
+++ b/tests/hubs/example-complex-forecast-hub/hub-config/predtimechart-config.yml
@@ -5,4 +5,3 @@ reference_date_col_name: 'reference_date'
 target_date_col_name: 'target_end_date'
 horizon_col_name: 'horizon'
 initial_checked_models: ['Flusight-baseline']
-disclaimer: Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends.

--- a/tests/hubs/example-complex-scenario-hub/hub-config/predtimechart-config.yml
+++ b/tests/hubs/example-complex-scenario-hub/hub-config/predtimechart-config.yml
@@ -5,4 +5,3 @@ reference_date_col_name: 'origin_date'
 target_date_col_name: 'origin_date'  # NB: this hub is invalid for predtimechart, which requires this column but is not present here. we use a placeholder so that the config file is valid
 horizon_col_name: 'horizon'
 initial_checked_models: ['Flusight-baseline']
-disclaimer: Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends.

--- a/tests/hubs/invalid-ptc-config-hub/hub-config/predtimechart-config.yml
+++ b/tests/hubs/invalid-ptc-config-hub/hub-config/predtimechart-config.yml
@@ -5,4 +5,3 @@ reference_date_col_name: 'reference_date'
 target_date_col_name: 'target_end_date'
 horizon_col_name: 'horizon'
 initial_checked_models: ['Flusight-baseline']
-disclaimer: Most forecasts have failed to reliably predict rapid changes in the trends of reported cases and hospitalizations. Due to this limitation, they should not be relied upon for decisions about the possibility or timing of rapid changes in trends.


### PR DESCRIPTION
closes [Update schema to comply with predtimechart 2.0.11 #22] by removing "disclaimer" from code and files. updates demo/index.html to predtimechart 2.0.11 . fixes default value for `reference_date_from_today()`, which was causing failed tests