### PR TITLE
refactor HubConfig to separate out general hub functionality from viz-specific functionality

### DIFF
--- a/src/hub_predtimechart/app/generate_json_files.py
+++ b/src/hub_predtimechart/app/generate_json_files.py
@@ -8,7 +8,7 @@ import structlog
 
 from hub_predtimechart.generate_data import forecast_data_for_model_df
 from hub_predtimechart.generate_options import ptc_options_for_hub
-from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.hub_config_ptc import HubConfigPtc
 from hub_predtimechart.util.logs import setup_logging
 
 
@@ -49,7 +49,7 @@ def main(hub_dir, ptc_config_file, options_file_out, forecasts_out_dir, regenera
     """
     logger.info(f"main({hub_dir=}, {ptc_config_file=}, {options_file_out=}, {forecasts_out_dir=}, {regenerate=}): "
                 f"entered")
-    hub_config = HubConfig(Path(hub_dir), Path(ptc_config_file))
+    hub_config = HubConfigPtc(Path(hub_dir), Path(ptc_config_file))
     json_files = _generate_json_files(hub_config, Path(forecasts_out_dir), regenerate)
     _generate_options_file(hub_config, Path(options_file_out))
     logger.info(f"main(): done: {len(json_files)} JSON files generated: {[str(_) for _ in json_files]}. "
@@ -60,7 +60,7 @@ def main(hub_dir, ptc_config_file, options_file_out, forecasts_out_dir, regenera
 # _generate_json_files() and helpers
 #
 
-def _generate_json_files(hub_config: HubConfig, output_dir: Path, is_regenerate: bool = False) -> list[Path]:
+def _generate_json_files(hub_config: HubConfigPtc, output_dir: Path, is_regenerate: bool = False) -> list[Path]:
     """
     Generates forecast json files from `hub_config`. Returns a list of Paths of the generated files.
 
@@ -74,10 +74,10 @@ def _generate_json_files(hub_config: HubConfig, output_dir: Path, is_regenerate:
     # their model_output files
     available_as_ofs = hub_config.get_available_ref_dates().values()
     newest_reference_date = max([max(date) for date in available_as_ofs])
-    df_cols_to_use = ([hub_config.target_col_name] + hub_config.viz_task_ids +
+    df_cols_to_use = ([hub_config.viz_target_col_name] + hub_config.viz_task_ids +
                       [hub_config.target_date_col_name, 'output_type', 'output_type_id', 'value'])
     json_files = []  # list of files actually loaded
-    for reference_date in hub_config.reference_dates:  # ex: ['2022-10-22', '2022-10-29', ...]
+    for reference_date in hub_config.viz_reference_dates:  # ex: ['2022-10-22', '2022-10-29', ...]
         # set model_id_to_df
         model_id_to_df: dict[str, pd.DataFrame] = {}
         for model_id in hub_config.model_id_to_metadata:  # ex: ['Flusight-baseline', 'MOBS-GLEAM_FLUH', ...]
@@ -97,7 +97,7 @@ def _generate_json_files(hub_config: HubConfig, output_dir: Path, is_regenerate:
         # iterate over each (target X task_ids) combination (for now we only support one target), outputting to the
         # corresponding json file
         for task_ids_tuple in hub_config.viz_task_ids_tuples:
-            json_file = generate_forecast_json_file(hub_config, model_id_to_df, output_dir, hub_config.target_id,
+            json_file = generate_forecast_json_file(hub_config, model_id_to_df, output_dir, hub_config.viz_target_id,
                                                     task_ids_tuple, reference_date, newest_reference_date,
                                                     is_regenerate)
             if json_file:
@@ -144,7 +144,7 @@ def json_file_name(target: str, task_ids_tuple: tuple[str], reference_date: str)
 
     :param target: string naming the target of interest
     :param task_ids_tuple: a tuple of task id values. ex: ('US', 'A-2021-03-05'). NB: assumes these are sorted according
-        to HubConfig.viz_task_ids
+        to HubConfigPtc.viz_task_ids
     :param reference_date: string naming the reference_date of interest
     :return: a "valid" file name
     """
@@ -164,7 +164,7 @@ def json_file_name(target: str, task_ids_tuple: tuple[str], reference_date: str)
 # _generate_options_file()
 #
 
-def _generate_options_file(hub_config: HubConfig, options_file: Path):
+def _generate_options_file(hub_config: HubConfigPtc, options_file: Path):
     """
     Generates a predtimechart config .json file from `hub_config` as documented at `ptc_options_for_hub()`, saving it to
     `options_file`. NB: `options_file` is overwritten if already present.

--- a/src/hub_predtimechart/generate_data.py
+++ b/src/hub_predtimechart/generate_data.py
@@ -2,10 +2,10 @@ from collections import defaultdict
 
 import pandas as pd
 
-from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.hub_config_ptc import HubConfigPtc
 
 
-def forecast_data_for_model_df(hub_config: HubConfig, model_df: pd.DataFrame, target: str, task_ids_tuple: tuple[str]):
+def forecast_data_for_model_df(hub_config: HubConfigPtc, model_df: pd.DataFrame, target: str, task_ids_tuple: tuple[str]):
     """
     Returns a dict for a single model in the forecast data format documented at https://github.com/reichlab/predtimechart?tab=readme-ov-file#fetchdata-forecasts-data-format .
     That is, looking at that example, this function returns the VALUE for a particular model, such as that of
@@ -24,7 +24,7 @@ def forecast_data_for_model_df(hub_config: HubConfig, model_df: pd.DataFrame, ta
     a JSON file.
     """
     # filter rows using a sequence of `query()` calls
-    model_df = model_df.query(f"{hub_config.target_col_name} == '{target}'")
+    model_df = model_df.query(f"{hub_config.viz_target_col_name} == '{target}'")
 
     for idx, viz_task_id in enumerate(hub_config.viz_task_ids):  # gives us task_ids_tuple order
         # hub_config.viz_task_ids ex:  'location', 'scenario_id'

--- a/src/hub_predtimechart/generate_options.py
+++ b/src/hub_predtimechart/generate_options.py
@@ -1,11 +1,11 @@
-from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.hub_config_ptc import HubConfigPtc
 
 
-def ptc_options_for_hub(hub_config: HubConfig):
+def ptc_options_for_hub(hub_config: HubConfigPtc):
     """
     Returns predtimechart options dict for `hub_config` - see https://github.com/reichlab/predtimechart?tab=readme-ov-file#options-object .
 
-    :param hub_config: a HubConfig
+    :param hub_config: a HubConfigPtc
     """
 
 
@@ -21,16 +21,16 @@ def ptc_options_for_hub(hub_config: HubConfig):
 
     def get_max_ref_date_or_first_config_ref_date(reference_dates):
         if len(reference_dates) == 0:
-            return min(hub_config.reference_dates)
+            return min(hub_config.viz_reference_dates)
         else:
             return max(reference_dates)
 
 
     # set `target_variables` and `initial_target_var`. recall that we currently only support one target
     options = {}
-    options['target_variables'] = [{'value': hub_config.target_id,
-                                    'text': hub_config.target_name,
-                                    'plot_text': hub_config.target_name}]
+    options['target_variables'] = [{'value': hub_config.viz_target_id,
+                                    'text': hub_config.viz_target_name,
+                                    'plot_text': hub_config.viz_target_name}]
     options['initial_target_var'] = options['target_variables'][0]['value']
 
     # set `task_ids` and `initial_task_ids`
@@ -46,7 +46,7 @@ def ptc_options_for_hub(hub_config: HubConfig):
     options['initial_interval'] = options['intervals'][-1]
 
     # set `available_as_ofs`, `initial_as_of`, and `current_date`
-    # available_as_ofs is the subset of hub_config.reference_dates for which
+    # available_as_ofs is the subset of hub_config.viz_reference_dates for which
     # there is at least one model output file
     options['available_as_ofs'] = hub_config.get_available_ref_dates()
     options['initial_as_of'] = max([get_max_ref_date_or_first_config_ref_date(reference_dates)

--- a/src/hub_predtimechart/hub_config.py
+++ b/src/hub_predtimechart/hub_config.py
@@ -1,271 +1,29 @@
-import datetime
-import itertools
 import json
-from collections import defaultdict
 from pathlib import Path
-from typing import Optional
-
-import pandas as pd
-import polars as pl
-import yaml
-from jsonschema import validate
-from jsonschema.exceptions import ValidationError
-
-from hub_predtimechart.ptc_schema import ptc_config_schema
 
 
 class HubConfig:
     """
-    Provides various visualization-related variables that are parsed from various places in `hub_dir`.
+    Provides convenient access to various parts of a hub's `tasks.json` file.
+
+    Instance variables:
+    - hub_dir: Path to a hub's root directory. see: https://hubverse.io/en/latest/user-guide/hub-structure.html
+    - tasks: the hub's `tasks.json` contents
+    - model_metadata_schema: the hub's `model-metadata-schema.json` contents
     """
 
 
-    def __init__(self, hub_dir: Path, ptc_config_file: Path):
+    def __init__(self, hub_dir: Path):
         """
         :param hub_dir: Path to a hub's root directory. see: https://hubverse.io/en/latest/user-guide/hub-structure.html
-        :param ptc_config_file: (input) a file Path to a `predtimechart-config.yaml` file that specifies how to process
-            `hub_dir` to get predtimechart output
         """
-        super().__init__()
-
-        # check for hub_dir
-        if not hub_dir.exists():
-            raise RuntimeError(f"hub_dir not found: {hub_dir}")
 
         self.hub_dir = hub_dir
+        if not self.hub_dir.exists():
+            raise RuntimeError(f"hub_dir not found: {self.hub_dir}")
 
-        # get tasks.json file content
         with open(self.hub_dir / 'hub-config' / 'tasks.json') as fp:
-            tasks = json.load(fp)
+            self.tasks: dict = json.load(fp)
 
-        # check for predtimechart config file
-        if not ptc_config_file.exists():
-            raise RuntimeError(f"predtimechart config file not found: {ptc_config_file}")
-
-        # load config settings from the predtimechart config file, first validating it
-        with open(ptc_config_file) as fp:
-            ptc_config = yaml.safe_load(fp)
-            try:
-                _validate_predtimechart_config(ptc_config, tasks)
-            except ValidationError as ve:
-                raise RuntimeError(f"invalid ptc_config_file. error='{ve}'")
-
-            # validate hub predtimechart compatibility. must be done after `_validate_predtimechart_config()`
-            with open(self.hub_dir / 'hub-config' / 'model-metadata-schema.json') as fp:
-                model_metadata_schema = json.load(fp)
-            _validate_hub_ptc_compatibility(ptc_config, tasks, model_metadata_schema)
-
-        self.rounds_idx = ptc_config['rounds_idx']
-        self.model_tasks_idx = ptc_config['model_tasks_idx']
-        self.reference_date_col_name = ptc_config['reference_date_col_name']
-        self.target_date_col_name = ptc_config['target_date_col_name']
-        self.horizon_col_name = ptc_config['horizon_col_name']
-        self.initial_checked_models = ptc_config['initial_checked_models']
-        self.disclaimer = ptc_config.get('disclaimer')
-
-        # set task_id_text. keys: task_ids, values: value-to-text dict. ex:
-        # {'location': {'US': 'United States', '01': 'Alabama', ..., '78': 'Virgin Islands'},  ...}
-        self.task_id_text = ptc_config.get('task_id_text')
-
-        # set model_ids
-        self.model_id_to_metadata = {}
-        for model_metadata_file in (list((self.hub_dir / 'model-metadata').glob('*.yml')) +
-                                    list((self.hub_dir / 'model-metadata').glob('*.yaml'))):
-            with open(model_metadata_file) as fp:
-                model_metadata = yaml.safe_load(fp)
-                model_id = f"{model_metadata['team_abbr']}-{model_metadata['model_abbr']}"
-                self.model_id_to_metadata[model_id] = model_metadata
-
-        # set task_ids
-        model_tasks_ele = tasks['rounds'][self.rounds_idx]['model_tasks'][self.model_tasks_idx]
-        self.task_ids = sorted(model_tasks_ele['task_ids'].keys())
-
-        # set target_data_file_name: either None (if the hub implements our new time-series target data standard) which
-        # means to use the fixed data file location "target-data/time-series.csv"), or the file name to look for in the
-        # "target-data" dir. use the function HubConfig.get_target_data_file_name() to access the actual file name
-        self.target_data_file_name = ptc_config.get('target_data_file_name')
-
-        # set target info and viz_task_ids. recall: we require exactly one `target_metadata` entry, and only one
-        # entry under its `target_keys`
-        target_metadata = model_tasks_ele['target_metadata'][0]
-        metadata_target_keys = target_metadata['target_keys']
-        self.target_id = list(metadata_target_keys.values())[0]
-        self.target_name = target_metadata['target_name']
-        self.target_col_name = list(metadata_target_keys.keys())[0]
-        self.viz_task_ids = sorted(set(self.task_ids) - {self.reference_date_col_name, self.target_date_col_name,
-                                                         self.horizon_col_name, self.target_col_name})
-
-        # set viz_task_id_to_vals
-        self.viz_task_id_to_vals = defaultdict(list)  # union of task_ids required and optional fields. each can be null
-        for viz_task_id in self.viz_task_ids:
-            required_vals = model_tasks_ele['task_ids'][viz_task_id]['required']
-            if required_vals:
-                self.viz_task_id_to_vals[viz_task_id].extend(required_vals)
-
-            optional_vals = model_tasks_ele['task_ids'][viz_task_id]['optional']
-            if optional_vals:
-                self.viz_task_id_to_vals[viz_task_id].extend(optional_vals)
-
-        # set viz_task_ids_tuples, sorted by self.viz_task_ids
-        viz_task_ids_values = [self.viz_task_id_to_vals[viz_task_id] for viz_task_id in self.viz_task_ids]
-        self.viz_task_ids_tuples = list(itertools.product(*viz_task_ids_values))
-
-        # set reference_dates
-        ref_date_task_id = model_tasks_ele['task_ids'][self.reference_date_col_name]
-        self.reference_dates = (ref_date_task_id['required'] if ref_date_task_id['required'] else []) + \
-                               (ref_date_task_id['optional'] if ref_date_task_id['optional'] else [])
-
-
-    def model_output_file_for_ref_date(self, model_id: str, reference_date: str) -> Optional[Path]:
-        """
-        Returns a Path to the model output file corresponding to `model_id` and `reference_date`. Returns None if none
-        found.
-        """
-        poss_output_files = [self.hub_dir / 'model-output' / model_id / f"{reference_date}-{model_id}.csv",
-                             self.hub_dir / 'model-output' / model_id / f"{reference_date}-{model_id}.parquet"]
-        for poss_output_file in poss_output_files:
-            if poss_output_file.exists():
-                return poss_output_file
-
-        return None
-
-
-    def get_available_ref_dates(self) -> dict[str, list[str]]:
-        """
-        Returns a list of reference_dates with at least one forecast file.
-        """
-
-
-        def get_sorted_values_or_first_config_ref_date(reference_dates: set[str]):
-            if len(reference_dates) == 0:
-                return [min(self.reference_dates)]
-            else:
-                return sorted(list(reference_dates))
-
-
-        # loop over every (reference_date X model_id) combination
-        target_id_to_ref_date = {self.target_id: set()}
-        for reference_date in self.reference_dates:  # ex: ['2022-10-22', '2022-10-29', ...]
-            for model_id in self.model_id_to_metadata:  # ex: ['Flusight-baseline', 'MOBS-GLEAM_FLUH', ...]
-                model_output_file = self.model_output_file_for_ref_date(model_id, reference_date)
-                if model_output_file:
-                    if model_output_file.suffix == '.csv':
-                        df = pd.read_csv(model_output_file, usecols=[self.target_col_name])
-                    elif model_output_file.suffix in ['.parquet', '.pqt']:
-                        df = pd.read_parquet(model_output_file, columns=[self.target_col_name])
-                    else:
-                        raise RuntimeError(f"unsupported model output file type: {model_output_file!r}. "
-                                           f"Only .csv and .parquet are supported")
-
-                    df = df.loc[df[self.target_col_name] == self.target_id, :]
-                    if not df.empty:
-                        target_id_to_ref_date[self.target_id].add(reference_date)
-
-        return {target_id: get_sorted_values_or_first_config_ref_date(reference_dates)
-                for target_id, reference_dates in target_id_to_ref_date.items()}
-
-
-    def get_target_data_df(self):
-        """
-        Loads the target data csv file from the hub repo for now, file path for target data is hard coded to 'target-data'.
-        Raises FileNotFoundError if target data file does not exist.
-        """
-        target_data_file_path = self.hub_dir / 'target-data' / self.get_target_data_file_name()
-        try:
-            # the override schema handles the 'US' location (the only location that doesn't parse as Int64)
-            # todo xx hard-coded column names
-            return pl.read_csv(target_data_file_path, schema_overrides={'location': pl.String,
-                                                                        'value': pl.Float64,
-                                                                        'observation': pl.Float64},
-                               null_values=["NA"])
-        except FileNotFoundError as error:
-            raise FileNotFoundError(f"target data file not found. {target_data_file_path=}, {error=}")
-
-
-    def get_target_data_file_name(self):
-        """
-        :return: the target data file name under the "target-data" dir to use
-        """
-        return self.target_data_file_name if self.target_data_file_name else 'time-series.csv'
-
-
-def _validate_hub_ptc_compatibility(ptc_config: dict, tasks: dict, model_metadata_schema: dict):
-    """
-    Validates a hub's predtimechart compatibility as identified in README.MD > Assumptions/limitations .
-
-    :param ptc_config: dict loaded from a 'predtimechart-config.yml' file
-    :param tasks: dict loaded from a hub's 'tasks.json' file
-    :param model_metadata_schema: dict loaded from a hub's 'model-metadata-schema.json' file
-    :raises ValidationError: if `tasks` is incompatible with predtimechart
-    """
-    # get the round and model_task
-    try:
-        the_round = tasks['rounds'][ptc_config['rounds_idx']]
-    except IndexError:
-        raise ValidationError(f"rounds_idx IndexError: #rounds={len(tasks['rounds'])}, "
-                              f"rounds_idx={ptc_config['rounds_idx']}")
-
-    try:
-        the_model_task = the_round['model_tasks'][ptc_config['model_tasks_idx']]
-    except IndexError:
-        raise ValidationError(f"model_tasks_idx IndexError: #model_tasks={len(the_round['model_tasks'])}, "
-                              f"model_tasks_idx={ptc_config['model_tasks_idx']}")
-
-    # validate: only `model_tasks` groups with `quantile` output_types will be considered
-    output_type = the_model_task['output_type']
-    if 'quantile' not in output_type:
-        raise ValidationError(f"no quantile output_type found. found types: {list(output_type.keys())}")
-
-    # validate: required quantile levels are present
-    quantile_levels = output_type['quantile']['output_type_id']['required']
-    req_quantile_levels = {0.025, 0.25, 0.5, 0.75, 0.975}
-    if not req_quantile_levels <= set(quantile_levels):  # subset
-        raise ValidationError(f"some quantile output_type_ids are missing. required={req_quantile_levels}, "
-                              f"found={set(quantile_levels)}")
-
-    # validate: in the specified `model_tasks` object within the specified `rounds` object, there is exactly one
-    # `target_metadata` entry, and only one entry under its `target_keys`
-    if len(the_model_task['target_metadata']) != 1:
-        raise ValidationError(f"not exactly one target_metadata object: {len(the_model_task['target_metadata'])}")
-
-    # validate: is_step_ahead
-    if not the_model_task['target_metadata'][0]['is_step_ahead']:
-        raise ValidationError("model_tasks entry's is_step_ahead must be true")
-
-    # validate: model metadata must contain a boolean `designated_model` field
-    if 'designated_model' not in model_metadata_schema['required']:
-        raise ValidationError(f"'designated_model' not found in model metadata schema's 'required' section")
-
-
-def _validate_predtimechart_config(ptc_config: dict, tasks: dict):
-    """
-    Validates `ptc_config` against the schema in ptc_schema.py.
-
-    :param ptc_config: dict loaded from a 'predtimechart-config.yml' file
-    :param tasks: dict loaded from a 'tasks.json' file
-    :raises ValidationError: if `ptc_config` is not valid
-    """
-    # validate against the JSON Schema and then do additional validations
-    validate(ptc_config, ptc_config_schema)
-
-    # validate: `rounds_idx` and `model_tasks_idx`
-    try:
-        tasks['rounds'][ptc_config['rounds_idx']]
-    except IndexError as ke:
-        raise ValidationError(f"invalid rounds_idx={ptc_config['rounds_idx']}. {ke=}")
-
-    the_round = tasks['rounds'][ptc_config['rounds_idx']]
-    try:
-        the_round['model_tasks'][ptc_config['model_tasks_idx']]
-    except IndexError as ke:
-        raise ValidationError(f"invalid model_tasks_idx={ptc_config['model_tasks_idx']}. {ke=}")
-
-    the_model_task = the_round['model_tasks'][ptc_config['model_tasks_idx']]
-
-    # validate: column names found in `task_ids`:
-    present_col_names = the_model_task['task_ids'].keys()
-    required_col_names = {ptc_config[req_col_name_config_key] for req_col_name_config_key in
-                          ['reference_date_col_name', 'target_date_col_name', 'horizon_col_name']}
-    if not required_col_names <= set(present_col_names):  # subset
-        raise ValidationError(f"some required columns are missing. required={required_col_names}, "
-                              f"found={set(present_col_names)}")
+        with open(self.hub_dir / 'hub-config' / 'model-metadata-schema.json') as fp:
+            self.model_metadata_schema: dict = json.load(fp)

--- a/src/hub_predtimechart/hub_config_ptc.py
+++ b/src/hub_predtimechart/hub_config_ptc.py
@@ -1,0 +1,275 @@
+import itertools
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import polars as pl
+import yaml
+from jsonschema import ValidationError, validate
+
+from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.ptc_schema import ptc_config_schema
+
+
+class HubConfigPtc(HubConfig):
+    """
+    A HubConfig subclass that adds various visualization-related variables from a hub.
+
+    Instance variables:
+    - rounds_idx: as loaded from `ptc_config_file`
+    - model_tasks_idx: ""
+    - reference_date_col_name: ""
+    - horizon_col_name: ""
+    - initial_checked_models: ""
+    - disclaimer: ""
+    - task_id_text: "". optional (None if not passed). keys: task_ids, values: value-to-text dict. ex:
+        {'location': {'US': 'United States', '01': 'Alabama', ..., '78': 'Virgin Islands'},  ...}
+    - model_id_to_metadata: maps model_ids (team_abbr + model_abbr) to metadata as loaded from files in the hub's
+        'model-metadata' dir. functions both as a map to metadata and as an iterable of model_ids (keys)
+    - target_data_file_name: either None (if the hub implements our new time-series target data standard) which means to
+        use the fixed data file location "target-data/time-series.csv"), or the file name to look for in the
+        "target-data" dir. use the function HubConfigPtc.get_target_data_file_name() to access the actual file name
+    - viz_target_id: target_metadata.target_keys[0].value
+    - viz_target_name: target_metadata.target_name
+    - viz_target_col_name: target_metadata.target_keys[0].key
+    - viz_task_ids: column names from model_tasks.task_ids.keys minus reference_date col, target_date col, horizon col,
+        and target col
+    - viz_task_id_to_vals: dict that maps task_ids (model_tasks.task_ids.keys) to a union of required and optional
+        fields
+    - viz_task_ids_tuples: the product of all viz task_id values
+    - viz_reference_dates: union of required and optional reference_dates from the reference column
+    """
+
+
+    def __init__(self, hub_dir: Path, ptc_config_file: Path):
+        """
+        :param hub_dir: as defined in HubConfig.__init__()
+        :param ptc_config_file: location of `predtimechart-config.yml` (or other named) file that matches ptc_schema.py.
+            this file specifies how to process `hub_dir` to get predtimechart output
+        """
+        super().__init__(hub_dir)
+
+        if not ptc_config_file.exists():
+            raise RuntimeError(f"predtimechart config file not found: {ptc_config_file}")
+
+        # load config settings from the predtimechart config file, first validating it
+        with open(ptc_config_file) as fp:
+            ptc_config = yaml.safe_load(fp)
+            try:
+                _validate_predtimechart_config(ptc_config, self.tasks)
+            except ValidationError as ve:
+                raise RuntimeError(f"invalid ptc_config_file. error='{ve}'")
+
+            # validate hub predtimechart compatibility. must be done after `_validate_predtimechart_config()`
+            _validate_hub_ptc_compatibility(ptc_config, self.tasks, self.model_metadata_schema)
+
+        self.rounds_idx: int = ptc_config['rounds_idx']
+        self.model_tasks_idx: int = ptc_config['model_tasks_idx']
+        self.reference_date_col_name: str = ptc_config['reference_date_col_name']
+        self.target_date_col_name = ptc_config['target_date_col_name']
+        self.horizon_col_name: str = ptc_config['horizon_col_name']
+        self.initial_checked_models: str = ptc_config['initial_checked_models']
+        self.disclaimer: str = ptc_config.get('disclaimer')  # optional
+        self.task_id_text: dict | None = ptc_config.get('task_id_text')  # optional
+
+        # set model_id_to_metadata
+        self.model_id_to_metadata: dict[str, dict] = {}
+        for model_metadata_file in (list((self.hub_dir / 'model-metadata').glob('*.yml')) +
+                                    list((self.hub_dir / 'model-metadata').glob('*.yaml'))):
+            with open(model_metadata_file) as fp:
+                model_metadata = yaml.safe_load(fp)
+                model_id = f"{model_metadata['team_abbr']}-{model_metadata['model_abbr']}"
+                self.model_id_to_metadata[model_id] = model_metadata
+
+        # set task_ids
+        model_tasks_ele = self.tasks['rounds'][self.rounds_idx]['model_tasks'][self.model_tasks_idx]
+        task_ids = sorted(model_tasks_ele['task_ids'].keys())
+
+        # set target_data_file_name
+        self.target_data_file_name = ptc_config.get('target_data_file_name')
+
+        # set target info and viz_task_ids. recall: we require exactly one `target_metadata` entry, and only one
+        # entry under its `target_keys`
+        target_metadata = model_tasks_ele['target_metadata'][0]
+        metadata_target_keys = target_metadata['target_keys']
+        self.viz_target_id = list(metadata_target_keys.values())[0]
+        self.viz_target_name = target_metadata['target_name']
+        self.viz_target_col_name = list(metadata_target_keys.keys())[0]
+        self.viz_task_ids = sorted(set(task_ids) - {self.reference_date_col_name, self.target_date_col_name,
+                                                    self.horizon_col_name, self.viz_target_col_name})
+
+        # set viz_task_id_to_vals
+        self.viz_task_id_to_vals = defaultdict(list)  # union of task_ids required and optional fields. each can be null
+        for viz_task_id in self.viz_task_ids:
+            required_vals = model_tasks_ele['task_ids'][viz_task_id]['required']
+            if required_vals:
+                self.viz_task_id_to_vals[viz_task_id].extend(required_vals)
+
+            optional_vals = model_tasks_ele['task_ids'][viz_task_id]['optional']
+            if optional_vals:
+                self.viz_task_id_to_vals[viz_task_id].extend(optional_vals)
+
+        # set viz_task_ids_tuples, sorted by self.viz_task_ids
+        viz_task_ids_values = [self.viz_task_id_to_vals[viz_task_id] for viz_task_id in self.viz_task_ids]
+        self.viz_task_ids_tuples = list(itertools.product(*viz_task_ids_values))
+
+        # set viz_reference_dates
+        ref_date_task_id = model_tasks_ele['task_ids'][self.reference_date_col_name]
+        self.viz_reference_dates = (ref_date_task_id['required'] if ref_date_task_id['required'] else []) + \
+                                   (ref_date_task_id['optional'] if ref_date_task_id['optional'] else [])
+
+
+    def model_output_file_for_ref_date(self, model_id: str, reference_date: str) -> Optional[Path]:
+        """
+        Returns a Path to the model output file corresponding to `model_id` and `reference_date`. Returns None if none
+        found.
+        """
+        poss_output_files = [self.hub_dir / 'model-output' / model_id / f"{reference_date}-{model_id}.csv",
+                             self.hub_dir / 'model-output' / model_id / f"{reference_date}-{model_id}.parquet"]
+        for poss_output_file in poss_output_files:
+            if poss_output_file.exists():
+                return poss_output_file
+
+        return None
+
+
+    def get_available_ref_dates(self) -> dict[str, list[str]]:
+        """
+        Returns a list of viz_reference_dates with at least one forecast file.
+        """
+
+
+        def get_sorted_values_or_first_config_ref_date(reference_dates: set[str]):
+            if len(reference_dates) == 0:
+                return [min(self.viz_reference_dates)]
+            else:
+                return sorted(list(reference_dates))
+
+
+        # loop over every (reference_date X model_id) combination
+        target_id_to_ref_date = {self.viz_target_id: set()}
+        for reference_date in self.viz_reference_dates:  # ex: ['2022-10-22', '2022-10-29', ...]
+            for model_id in self.model_id_to_metadata:  # ex: ['Flusight-baseline', 'MOBS-GLEAM_FLUH', ...]
+                model_output_file = self.model_output_file_for_ref_date(model_id, reference_date)
+                if model_output_file:
+                    if model_output_file.suffix == '.csv':
+                        df = pd.read_csv(model_output_file, usecols=[self.viz_target_col_name])
+                    elif model_output_file.suffix in ['.parquet', '.pqt']:
+                        df = pd.read_parquet(model_output_file, columns=[self.viz_target_col_name])
+                    else:
+                        raise RuntimeError(f"unsupported model output file type: {model_output_file!r}. "
+                                           f"Only .csv and .parquet are supported")
+
+                    df = df.loc[df[self.viz_target_col_name] == self.viz_target_id, :]
+                    if not df.empty:
+                        target_id_to_ref_date[self.viz_target_id].add(reference_date)
+
+        return {target_id: get_sorted_values_or_first_config_ref_date(reference_dates)
+                for target_id, reference_dates in target_id_to_ref_date.items()}
+
+
+    def get_target_data_df(self):
+        """
+        Loads the target data csv file from the hub repo for now, file path for target data is hard coded to 'target-data'.
+        Raises FileNotFoundError if target data file does not exist.
+        """
+        target_data_file_path = self.hub_dir / 'target-data' / self.get_target_data_file_name()
+        try:
+            # the override schema handles the 'US' location (the only location that doesn't parse as Int64)
+            # todo xx hard-coded column names
+            return pl.read_csv(target_data_file_path, schema_overrides={'location': pl.String,
+                                                                        'value': pl.Float64,
+                                                                        'observation': pl.Float64},
+                               null_values=["NA"])
+        except FileNotFoundError as error:
+            raise FileNotFoundError(f"target data file not found. {target_data_file_path=}, {error=}")
+
+
+    def get_target_data_file_name(self):
+        """
+        :return: the target data file name under the "target-data" dir to use
+        """
+        return self.target_data_file_name if self.target_data_file_name else 'time-series.csv'
+
+
+def _validate_predtimechart_config(ptc_config: dict, tasks: dict):
+    """
+    Validates `ptc_config` against the schema in ptc_schema.py.
+
+    :param ptc_config: dict loaded from a 'predtimechart-config.yml' file
+    :param tasks: dict loaded from a 'tasks.json' file
+    :raises ValidationError: if `ptc_config` is not valid
+    """
+    # validate against the JSON Schema and then do additional validations
+    validate(ptc_config, ptc_config_schema)
+
+    # validate: `rounds_idx` and `model_tasks_idx`
+    try:
+        tasks['rounds'][ptc_config['rounds_idx']]
+    except IndexError as ke:
+        raise ValidationError(f"invalid rounds_idx={ptc_config['rounds_idx']}. {ke=}")
+
+    the_round = tasks['rounds'][ptc_config['rounds_idx']]
+    try:
+        the_round['model_tasks'][ptc_config['model_tasks_idx']]
+    except IndexError as ke:
+        raise ValidationError(f"invalid model_tasks_idx={ptc_config['model_tasks_idx']}. {ke=}")
+
+    the_model_task = the_round['model_tasks'][ptc_config['model_tasks_idx']]
+
+    # validate: column names found in `task_ids`:
+    present_col_names = the_model_task['task_ids'].keys()
+    required_col_names = {ptc_config[req_col_name_config_key] for req_col_name_config_key in
+                          ['reference_date_col_name', 'target_date_col_name', 'horizon_col_name']}
+    if not required_col_names <= set(present_col_names):  # subset
+        raise ValidationError(f"some required columns are missing. required={required_col_names}, "
+                              f"found={set(present_col_names)}")
+
+
+def _validate_hub_ptc_compatibility(ptc_config: dict, tasks: dict, model_metadata_schema: dict):
+    """
+    Validates a hub's predtimechart compatibility as identified in README.MD > Assumptions/limitations .
+
+    :param ptc_config: dict loaded from a 'predtimechart-config.yml' file
+    :param tasks: dict loaded from a hub's 'tasks.json' file
+    :param model_metadata_schema: dict loaded from a hub's 'model-metadata-schema.json' file
+    :raises ValidationError: if `tasks` is incompatible with predtimechart
+    """
+    # get the round and model_task
+    try:
+        the_round = tasks['rounds'][ptc_config['rounds_idx']]
+    except IndexError:
+        raise ValidationError(f"rounds_idx IndexError: #rounds={len(tasks['rounds'])}, "
+                              f"rounds_idx={ptc_config['rounds_idx']}")
+
+    try:
+        the_model_task = the_round['model_tasks'][ptc_config['model_tasks_idx']]
+    except IndexError:
+        raise ValidationError(f"model_tasks_idx IndexError: #model_tasks={len(the_round['model_tasks'])}, "
+                              f"model_tasks_idx={ptc_config['model_tasks_idx']}")
+
+    # validate: only `model_tasks` groups with `quantile` output_types will be considered
+    output_type = the_model_task['output_type']
+    if 'quantile' not in output_type:
+        raise ValidationError(f"no quantile output_type found. found types: {list(output_type.keys())}")
+
+    # validate: required quantile levels are present
+    quantile_levels = output_type['quantile']['output_type_id']['required']
+    req_quantile_levels = {0.025, 0.25, 0.5, 0.75, 0.975}
+    if not req_quantile_levels <= set(quantile_levels):  # subset
+        raise ValidationError(f"some quantile output_type_ids are missing. required={req_quantile_levels}, "
+                              f"found={set(quantile_levels)}")
+
+    # validate: in the specified `model_tasks` object within the specified `rounds` object, there is exactly one
+    # `target_metadata` entry, and only one entry under its `target_keys`
+    if len(the_model_task['target_metadata']) != 1:
+        raise ValidationError(f"not exactly one target_metadata object: {len(the_model_task['target_metadata'])}")
+
+    # validate: is_step_ahead
+    if not the_model_task['target_metadata'][0]['is_step_ahead']:
+        raise ValidationError("model_tasks entry's is_step_ahead must be true")
+
+    # validate: model metadata must contain a boolean `designated_model` field
+    if 'designated_model' not in model_metadata_schema['required']:
+        raise ValidationError(f"'designated_model' not found in model metadata schema's 'required' section")

--- a/tests/hub_predtimechart/test_generate_data.py
+++ b/tests/hub_predtimechart/test_generate_data.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from hub_predtimechart.app.generate_json_files import json_file_name
 from hub_predtimechart.generate_data import forecast_data_for_model_df
-from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.hub_config_ptc import HubConfigPtc
 
 
 def test_json_file_name():
@@ -18,7 +18,7 @@ def test_json_file_name():
 
 def test_forecast_data_for_model_df_complex_forecast_hub_US():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     with open('tests/expected/example-complex-forecast-hub/forecasts/wk-inc-flu-hosp_US_2022-10-22.json') as fp:
         exp_data = json.load(fp)
@@ -43,7 +43,7 @@ def test_forecast_data_for_model_df_complex_forecast_hub_US():
 
 def test_forecast_data_for_model_df_complex_forecast_hub_01():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     with open('tests/expected/example-complex-forecast-hub/forecasts/wk-inc-flu-hosp_01_2022-10-22.json') as fp:
         exp_data = json.load(fp)
@@ -68,7 +68,7 @@ def test_forecast_data_for_model_df_complex_forecast_hub_01():
 
 def test_forecast_data_for_model_df_no_data():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
 
     model_output_file = hub_dir / 'model-output/Flusight-baseline/2022-10-22-Flusight-baseline.csv'
     act_data = forecast_data_for_model_df(hub_config, pd.read_csv(model_output_file), 'wk inc flu hosp', ('01',))

--- a/tests/hub_predtimechart/test_generate_json_files.py
+++ b/tests/hub_predtimechart/test_generate_json_files.py
@@ -3,7 +3,7 @@ import shutil
 from pathlib import Path
 
 from hub_predtimechart.app.generate_json_files import _generate_json_files, _generate_options_file
-from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.hub_config_ptc import HubConfigPtc
 
 
 def test_generate_json_files(tmp_path):
@@ -11,7 +11,7 @@ def test_generate_json_files(tmp_path):
     An integration test of `generate_json_files.py`'s `_generate_json_files()`.
     """
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     output_dir = tmp_path
     json_files = _generate_json_files(hub_config, output_dir)
     assert set(json_files) == {output_dir / 'wk-inc-flu-hosp_US_2022-10-22.json',
@@ -34,7 +34,7 @@ def test_generate_json_files_skip_files(tmp_path):
     This validates that only new data will be generated
     """
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     output_dir = tmp_path
 
     # copy all but one prediction to the output directory
@@ -67,7 +67,7 @@ def test_generate_json_files_regenerate(tmp_path):
     This validates that only new data will be generated
     """
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     output_dir = tmp_path
 
     # copy all but one prediction to the output directory
@@ -88,7 +88,7 @@ def test_generate_options_file(tmp_path):
     An integration test of `generate_json_files.py`'s `_generate_options_file()`.
     """
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     ptc_options = tmp_path / 'ptc_options'
     _generate_options_file(hub_config, ptc_options)
     with open(ptc_options) as act_options_fp, \

--- a/tests/hub_predtimechart/test_generate_options.py
+++ b/tests/hub_predtimechart/test_generate_options.py
@@ -2,12 +2,12 @@ import json
 from pathlib import Path
 
 from hub_predtimechart.generate_options import ptc_options_for_hub
-from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.hub_config_ptc import HubConfigPtc
 
 
 def test_generate_options_complex_forecast_hub():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     with open('tests/expected/example-complex-forecast-hub/predtimechart-options.json') as fp:
         exp_options = json.load(fp)
     act_options = ptc_options_for_hub(hub_config)
@@ -22,7 +22,7 @@ def test_generate_options_complex_forecast_hub():
 
 def test_generate_options_complex_forecast_hub_no_disclaimer():
     hub_dir = Path('tests/hubs/example-complex-forecast-hub')
-    hub_config = HubConfig(hub_dir, Path('tests/configs/example-complex-no-disclaimer.yml'))
+    hub_config = HubConfigPtc(hub_dir, Path('tests/configs/example-complex-no-disclaimer.yml'))
     with open('tests/expected/example-complex-forecast-hub/predtimechart-options.json') as fp:
         exp_options = json.load(fp)
     act_options = ptc_options_for_hub(hub_config)
@@ -31,7 +31,7 @@ def test_generate_options_complex_forecast_hub_no_disclaimer():
 
 def test_generate_options_flusight_forecast_hub():
     hub_dir = Path('tests/hubs/FluSight-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     with open('tests/expected/FluSight-forecast-hub/predtimechart-options.json') as fp:
         exp_options = json.load(fp)
     act_options = ptc_options_for_hub(hub_config)
@@ -40,7 +40,7 @@ def test_generate_options_flusight_forecast_hub():
 
 def test_generate_options_flu_metrocast():
     hub_dir = Path('tests/hubs/flu-metrocast')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     with open('tests/expected/flu-metrocast/predtimechart-options.json') as fp:
         exp_options = json.load(fp)
     act_options = ptc_options_for_hub(hub_config)
@@ -49,7 +49,7 @@ def test_generate_options_flu_metrocast():
 
 def test_generate_options_task_id_text_covid19_forecast_hub():
     hub_dir = Path('tests/hubs/covid19-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     with open('tests/expected/covid19-forecast-hub/predtimechart-options.json') as fp:
         exp_options = json.load(fp)
     act_options = ptc_options_for_hub(hub_config)

--- a/tests/hub_predtimechart/test_generate_target_data.py
+++ b/tests/hub_predtimechart/test_generate_target_data.py
@@ -8,12 +8,12 @@ from freezegun import freeze_time
 
 from hub_predtimechart.app.generate_target_json_files import reference_date_from_today, ptc_target_data, \
     _max_as_of_le__reference_date
-from hub_predtimechart.hub_config import HubConfig
+from hub_predtimechart.hub_config_ptc import HubConfigPtc
 
 
 def test_ptc_target_data_flusight_forecast_hub():
     hub_dir = Path('tests/hubs/FluSight-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     target_data_df = hub_config.get_target_data_df()
     for loc in ['US', '01']:
         task_ids_tuple = (loc,)
@@ -25,7 +25,7 @@ def test_ptc_target_data_flusight_forecast_hub():
 
 def test_ptc_target_data_covid19_forecast_hub():
     hub_dir = Path('tests/hubs/covid19-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     target_data_df = hub_config.get_target_data_df()
     for loc in ['US', '01']:
         task_ids_tuple = (loc,)
@@ -37,7 +37,7 @@ def test_ptc_target_data_covid19_forecast_hub():
 
 def test_ptc_target_data_flu_metrocast():
     hub_dir = Path('tests/hubs/flu-metrocast')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     target_data_df = hub_config.get_target_data_df()
     # 2025-02-25 is the newest as_of in tests/hubs/flu-metrocast time-series.csv. we use 2025-03-01 for
     # reference_date b/c that's the one right after 2025-02-25 (but we could have used any reference_date after
@@ -69,7 +69,7 @@ def test_reference_date_from_today():
 
 def test_get_target_data_df_error_cases():
     hub_dir = Path('tests/hubs/FluSight-forecast-hub')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     hub_config.target_data_file_name = 'target-hospital-admissions-no-na.csv'  # override
     act_target_data_df = hub_config.get_target_data_df()
     assert act_target_data_df['value'].dtype == pl.datatypes.Float64
@@ -88,7 +88,7 @@ def test_get_target_data_df_error_cases():
 
 def test__max_as_of_le__reference_date():
     hub_dir = Path('tests/hubs/flu-metrocast')
-    hub_config = HubConfig(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
+    hub_config = HubConfigPtc(hub_dir, hub_dir / 'hub-config/predtimechart-config.yml')
     target_data_df = hub_config.get_target_data_df()
     for ref_date, exp_max_as_of in [('2025-01-29', None), ('2025-02-12', '2025-02-12'), ('2025-02-13', '2025-02-12'),
                                     ('2025-02-26', '2025-02-25')]:

--- a/tests/hubs/invalid-ptc-config-hub/hub-config/model-metadata-schema.json
+++ b/tests/hubs/invalid-ptc-config-hub/hub-config/model-metadata-schema.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Schema for Flu MetroCast Hub model metadata",
+    "description": "This is the schema for model metadata files, please refer to https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Metadata for more information.",
+    "type": "object",
+    "properties": {
+        "team_name": {
+            "description": "The name of the team submitting the model",
+            "type": "string"
+        },
+        "team_abbr": {
+            "description": "Abbreviated name of the team submitting the model",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_+]+$",
+            "maxLength": 16
+        },
+        "model_name": {
+            "description": "The name of the model",
+            "type": "string"
+        },
+        "model_abbr": {
+            "description": "Abbreviated name of the model",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_+]+$",
+            "maxLength": 16
+        },
+        "model_version": {
+            "description": "Identifier of the version of the model",
+            "type": "string"
+        },
+        "model_contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string",
+                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "repo_url": {
+            "description": "Repository containing code for the model",
+            "type": "string",
+            "format": "uri"
+        },
+        "license": {
+            "description": "License for use of model output data",
+            "type": "string",
+            "enum": [
+                "CC0-1.0",
+                "CC-BY-4.0",
+                "CC-BY_SA-4.0",
+                "PPDL",
+                "ODC-by",
+                "ODbL",
+                "OGL-3.0"
+            ]
+        },
+        "designated_model": {
+            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization.",
+            "type": "boolean"
+        },
+        "citation": {
+            "description": "One or more citations for this model",
+            "type": "string",
+            "examples": [
+                "Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"
+            ]
+        },
+        "team_funding": {
+            "description": "Any information about funding source for the team or members of the team.",
+            "type": "string",
+            "examples": [
+                "National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."
+            ]
+        },
+        "methods": {
+            "description": "A summary of the methods used by this model (5000 character limit).",
+            "type": "string",
+            "maxLength": 5000
+        },
+        "methods_url": {
+            "description": "A link to a complete write-up of the model specification, with mathematical details. This could be a peer-reviewed article, preprint, or an unpublished PDF or webpage stored at a public url somewhere.",
+            "type": "string",
+            "format": "uri"
+        },
+        "data_sources": {
+            "description": "List or description of data inputs used by the model. For example: public data from NYC DOHMH, CDC NSSP surveillance data, etc...",
+            "type": "string"
+        },
+        "ensemble_of_hub_models": {
+            "description": "Indicator for whether this model is an ensemble of other Hub models",
+            "type": "boolean"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "team_name",
+        "team_abbr",
+        "model_name",
+        "model_abbr",
+        "model_contributors",
+        "license",
+        "designated_model",
+        "methods",
+        "data_sources"
+    ]
+}

--- a/tests/hubs/no-ptc-config-hub/hub-config/model-metadata-schema.json
+++ b/tests/hubs/no-ptc-config-hub/hub-config/model-metadata-schema.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Schema for Flu MetroCast Hub model metadata",
+    "description": "This is the schema for model metadata files, please refer to https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/wiki/Metadata for more information.",
+    "type": "object",
+    "properties": {
+        "team_name": {
+            "description": "The name of the team submitting the model",
+            "type": "string"
+        },
+        "team_abbr": {
+            "description": "Abbreviated name of the team submitting the model",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_+]+$",
+            "maxLength": 16
+        },
+        "model_name": {
+            "description": "The name of the model",
+            "type": "string"
+        },
+        "model_abbr": {
+            "description": "Abbreviated name of the model",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_+]+$",
+            "maxLength": 16
+        },
+        "model_version": {
+            "description": "Identifier of the version of the model",
+            "type": "string"
+        },
+        "model_contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string",
+                        "pattern": "^\\d{4}\\-\\d{4}\\-\\d{4}\\-[\\dX]{4}$"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "repo_url": {
+            "description": "Repository containing code for the model",
+            "type": "string",
+            "format": "uri"
+        },
+        "license": {
+            "description": "License for use of model output data",
+            "type": "string",
+            "enum": [
+                "CC0-1.0",
+                "CC-BY-4.0",
+                "CC-BY_SA-4.0",
+                "PPDL",
+                "ODC-by",
+                "ODbL",
+                "OGL-3.0"
+            ]
+        },
+        "designated_model": {
+            "description": "Team-specified indicator for whether the model should be eligible for inclusion in a Hub ensemble and public visualization.",
+            "type": "boolean"
+        },
+        "citation": {
+            "description": "One or more citations for this model",
+            "type": "string",
+            "examples": [
+                "Gibson GC , Reich NG , Sheldon D. Real-time mechanistic bayesian forecasts of Covid-19 mortality. medRxiv. 2020. https://doi.org/10.1101/2020.12.22.20248736"
+            ]
+        },
+        "team_funding": {
+            "description": "Any information about funding source for the team or members of the team.",
+            "type": "string",
+            "examples": [
+                "National Institutes of General Medical Sciences (R01GM123456). The content is solely the responsibility of the authors and does not necessarily represent the official views of NIGMS."
+            ]
+        },
+        "methods": {
+            "description": "A summary of the methods used by this model (5000 character limit).",
+            "type": "string",
+            "maxLength": 5000
+        },
+        "methods_url": {
+            "description": "A link to a complete write-up of the model specification, with mathematical details. This could be a peer-reviewed article, preprint, or an unpublished PDF or webpage stored at a public url somewhere.",
+            "type": "string",
+            "format": "uri"
+        },
+        "data_sources": {
+            "description": "List or description of data inputs used by the model. For example: public data from NYC DOHMH, CDC NSSP surveillance data, etc...",
+            "type": "string"
+        },
+        "ensemble_of_hub_models": {
+            "description": "Indicator for whether this model is an ensemble of other Hub models",
+            "type": "boolean"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "team_name",
+        "team_abbr",
+        "model_name",
+        "model_abbr",
+        "model_contributors",
+        "license",
+        "designated_model",
+        "methods",
+        "data_sources"
+    ]
+}


### PR DESCRIPTION
This commit is a precursor to [add support for multiple model tasks #38]. Reviewer notes:

- we now have a general HubConfig superclass and a HubConfigPtc Predtimechart-specific subclass
- I've renamed some fields to start with 'viz_' to clarify that they're viz-specific
- most diffs are due to these two changes
- I had to add arbitrary model-metadata-schema.json files to two test hubs b/c validation is ordered differently due to super/subclass refactor
