### PR TITLE
sort initial_checked_models to top of models list

### DIFF
--- a/src/hub_predtimechart/generate_options.py
+++ b/src/hub_predtimechart/generate_options.py
@@ -70,7 +70,8 @@ def ptc_options_for_hub(hub_config: HubConfigPtc):
     for model_id, metadata in hub_config.model_id_to_metadata.items():
         if metadata['designated_model'] or model_id in hub_config.initial_checked_models:
             options['models'].append(model_id)
-    options['models'].sort()
+    options['models'].sort(key=lambda model_id: (model_id not in hub_config.initial_checked_models,
+                                                 model_id))  # put initial_checked_models at top
     options['initial_checked_models'] = hub_config.initial_checked_models
 
     # set `model_urls`

--- a/tests/expected/FluSight-forecast-hub/predtimechart-options.json
+++ b/tests/expected/FluSight-forecast-hub/predtimechart-options.json
@@ -73,8 +73,7 @@
   },
   "initial_as_of": "2024-05-04",
   "current_date": "2024-05-04",
-  "models": [
-    "CADPH-FluCAT_Ensemble", "CEPH-Rtrend_fluH", "CMU-TimeSeries", "CU-ensemble", "FluSight-baseline", "FluSight-ensemble", "GT-FluFNP", "ISU_NiemiLab-NLH", "JHU_CSSE-CSSE_Ensemble", "LUcompUncertLab-chimera", "LosAlamos_NAU-CModel_Flu", "MIGHTE-Nsemble", "MOBS-GLEAM_FLUH", "NIH-Flu_ARIMA", "NU_UCSD-GLEAM_AI_FLUH", "PSI-PROF", "SGroup-RandomForest", "SigSci-CREG", "SigSci-TSENS", "Stevens-GBR", "UGA_flucast-Copycat", "UGA_flucast-INFLAenza", "UGuelph-CompositeCurve", "UGuelphensemble-GRYPHON", "UM-DeepOutbreak", "UMass-flusion", "UMass-trends_ensemble", "UNC_IDD-InfluPaint", "UVAFluX-Ensemble", "VTSanghani-Ensemble", "cfa-flumech", "cfarenewal-cfaepimlight", "fjordhest-ensemble"
+  "models": ["FluSight-baseline", "FluSight-ensemble", "CADPH-FluCAT_Ensemble", "CEPH-Rtrend_fluH", "CMU-TimeSeries", "CU-ensemble", "GT-FluFNP", "ISU_NiemiLab-NLH", "JHU_CSSE-CSSE_Ensemble", "LUcompUncertLab-chimera", "LosAlamos_NAU-CModel_Flu", "MIGHTE-Nsemble", "MOBS-GLEAM_FLUH", "NIH-Flu_ARIMA", "NU_UCSD-GLEAM_AI_FLUH", "PSI-PROF", "SGroup-RandomForest", "SigSci-CREG", "SigSci-TSENS", "Stevens-GBR", "UGA_flucast-Copycat", "UGA_flucast-INFLAenza", "UGuelph-CompositeCurve", "UGuelphensemble-GRYPHON", "UM-DeepOutbreak", "UMass-flusion", "UMass-trends_ensemble", "UNC_IDD-InfluPaint", "UVAFluX-Ensemble", "VTSanghani-Ensemble", "cfa-flumech", "cfarenewal-cfaepimlight", "fjordhest-ensemble"
   ],
   "model_urls": {
     "CADPH-FluCAT_Ensemble": "https://github.com/cdcepi/FluSight-forecast-hub/blob/main/model-metadata/CADPH-FluCAT_Ensemble.yml",


### PR DESCRIPTION
Addresses predtimechart issue: [[initial_checked_models should go at top #50]](https://github.com/reichlab/predtimechart/issues/50). Note that we solve it here in hub-dashboard-predtimechart as discussed in that issue.

Changes:
- `ptc_options_for_hub()`: sort so that **initial_checked_models** are at the top. uses the `sort()` function's `key` param's _multilevel sorting (sorting by multiple criteria)_ feature by returning a 2-tuple: `(is_not_checked_model, model_id)`.
- fixes the corresponding test .json file