### PR TITLE
change predtimechart.bundle.js import to use `predtimechart@v3`

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -34,7 +34,7 @@
 </div>
 
 <script type="module">
-    import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@3.1.5/dist/predtimechart.bundle.js';
+    import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@v3/dist/predtimechart.bundle.js';
     document.predtimechart = App;  // for debugging
 
     function replace_chars(the_string) {


### PR DESCRIPTION
I decided to use `predtimechart@v3` in. the `import` to match https://github.com/hubverse-org/hub-dash-site-builder/blob/main/static/resources/predtimechart.js so we don't have to change this file with every predtimechart release.