### PR TITLE
Add Support For Parquet File Types For Target Data

### DIFF
--- a/src/hub_predtimechart/hub_config_ptc.py
+++ b/src/hub_predtimechart/hub_config_ptc.py
@@ -127,21 +127,28 @@ class HubConfigPtc(HubConnection):
         predtimechart config.
 
         :return: target data as a polars DataFrame
-        :raises FileNotFoundError: if target data file does 
-                not exist
-        :raises ValueError: if target data file has 
-                            unsupported format (custom file only)
+        :raises RuntimeError: if hubdata fails to retrieve target data
+        :raises FileNotFoundError: if target data file does not exist
+        :raises ValueError: if target data file has unsupported format
         """
         # use hubdata.connect_target_data() for standard file locations
         if not self.target_data_file_name:
             try:
                 target_conn = connect_target_data(self.hub_path, TargetType.TIME_SERIES)
                 return pl.from_arrow(target_conn.to_table())
-            except RuntimeError as error:
-                raise FileNotFoundError(f"target data not found via hubdata. {error=}")
+            except Exception as error:
+                raise RuntimeError(f"failed to retrieve target data via hubdata. {error=}")
 
         # fallback for custom file name specified in config
         target_data_file_path = self.hub_path / "target-data" / self.target_data_file_name
+
+        # check extension before attempting to read
+        if target_data_file_path.suffix not in (".csv", ".parquet"):
+            raise ValueError(
+                f"Unsupported target data file format: {target_data_file_path.suffix}. "
+                f"Only .csv and .parquet are supported."
+            )
+
         try:
             if target_data_file_path.suffix == ".csv":
                 return pl.read_csv(
@@ -153,30 +160,17 @@ class HubConfigPtc(HubConnection):
                     },
                     null_values=["NA"],
                 )
-            elif target_data_file_path.suffix == ".parquet":
-                return pl.read_parquet(target_data_file_path)
             else:
-                raise ValueError(
-                    f"Unsupported target data file format: {target_data_file_path.suffix}. "
-                    f"Only .csv and .parquet are supported."
-                )
+                return pl.read_parquet(target_data_file_path)
         except FileNotFoundError as error:
             raise FileNotFoundError(f"target data file not found. {target_data_file_path=}, {error=}")
 
 
     def get_target_data_file_name(self):
         """
-        :return: the target data file name under the "target-data" dir to use.
-                 If not specified in config, defaults to 'time-series.csv' if
-                 it exists, otherwise falls back to 'time-series.parquet'.
+        :return: the target data file name under the "target-data" dir to use
         """
-        if self.target_data_file_name:
-            return self.target_data_file_name
-        # prefer csv over parquet
-        csv_path = self.hub_path / 'target-data' / 'time-series.csv'
-        if csv_path.exists():
-            return 'time-series.csv'
-        return 'time-series.parquet'
+        return self.target_data_file_name if self.target_data_file_name else 'time-series.csv'
 
 
 def _validate_predtimechart_config(ptc_config: dict, tasks: dict):

--- a/src/hub_predtimechart/hub_config_ptc.py
+++ b/src/hub_predtimechart/hub_config_ptc.py
@@ -117,26 +117,50 @@ class HubConfigPtc(HubConnection):
 
     def get_target_data_df(self) -> pl.DataFrame:
         """
-        Loads the target data csv file from the hub repo for now, file path for target data is hard coded to 'target-data'.
-        Raises FileNotFoundError if target data file does not exist.
+        Loads the target data file from the hub repo.
+        Supports both CSV and parquet formats. File path
+        for target data is hard coded to 'target-data'.
+        Raises FileNotFoundError if target data file does
+        not exist.
         """
         target_data_file_path = self.hub_path / 'target-data' / self.get_target_data_file_name()
         try:
-            # the override schema handles the 'US' location (the only location that doesn't parse as Int64)
+            # the override schema handles the 'US' location (the only location
+            # that doesn't parse as Int64)
             # todo hard-coded column names
-            return pl.read_csv(target_data_file_path, schema_overrides={'location': pl.String,
-                                                                        'value': pl.Float64,
-                                                                        'observation': pl.Float64},
-                               null_values=["NA"])
+            if target_data_file_path.suffix == '.csv':
+                return pl.read_csv(
+                    target_data_file_path,
+                    schema_overrides={
+                        'location': pl.String,
+                        'value': pl.Float64,
+                        'observation': pl.Float64},
+                    null_values=["NA"]
+                )
+            elif target_data_file_path.suffix == '.parquet':
+                return pl.read_parquet(target_data_file_path)
+            else:
+                raise ValueError(
+                    f"Unsupported target data file format: {target_data_file_path.suffix}. "
+                    f"Only .csv and .parquet are supported."
+                )
         except FileNotFoundError as error:
             raise FileNotFoundError(f"target data file not found. {target_data_file_path=}, {error=}")
 
 
     def get_target_data_file_name(self):
         """
-        :return: the target data file name under the "target-data" dir to use
+        :return: the target data file name under the "target-data" dir to use.
+                 If not specified in config, defaults to 'time-series.csv' if
+                 it exists, otherwise falls back to 'time-series.parquet'.
         """
-        return self.target_data_file_name if self.target_data_file_name else 'time-series.csv'
+        if self.target_data_file_name:
+            return self.target_data_file_name
+        # prefer csv over parquet
+        csv_path = self.hub_path / 'target-data' / 'time-series.csv'
+        if csv_path.exists():
+            return 'time-series.csv'
+        return 'time-series.parquet'
 
 
 def _validate_predtimechart_config(ptc_config: dict, tasks: dict):

--- a/src/hub_predtimechart/hub_config_ptc.py
+++ b/src/hub_predtimechart/hub_config_ptc.py
@@ -8,6 +8,7 @@ import pandas as pd
 import polars as pl
 import yaml
 from hubdata import HubConnection
+from hubdata.connect_target_data import TargetType, connect_target_data
 from jsonschema import FormatChecker, ValidationError, validate
 
 from hub_predtimechart.ptc_schema import ptc_config_schema
@@ -117,27 +118,42 @@ class HubConfigPtc(HubConnection):
 
     def get_target_data_df(self) -> pl.DataFrame:
         """
-        Loads the target data file from the hub repo.
-        Supports both CSV and parquet formats. File path
-        for target data is hard coded to 'target-data'.
-        Raises FileNotFoundError if target data file does
-        not exist.
+        Loads the target data file from the hub repo. 
+        Uses hubdata.connect_target_data() for standard 
+        target data locations (time-series.csv, 
+        time-series.parquet, or time-series/ directory). 
+        Falls back to custom file reading when 
+        target_data_file_name is specified in the 
+        predtimechart config.
+
+        :return: target data as a polars DataFrame
+        :raises FileNotFoundError: if target data file does 
+                not exist
+        :raises ValueError: if target data file has 
+                            unsupported format (custom file only)
         """
-        target_data_file_path = self.hub_path / 'target-data' / self.get_target_data_file_name()
+        # use hubdata.connect_target_data() for standard file locations
+        if not self.target_data_file_name:
+            try:
+                target_conn = connect_target_data(self.hub_path, TargetType.TIME_SERIES)
+                return pl.from_arrow(target_conn.to_table())
+            except RuntimeError as error:
+                raise FileNotFoundError(f"target data not found via hubdata. {error=}")
+
+        # fallback for custom file name specified in config
+        target_data_file_path = self.hub_path / "target-data" / self.target_data_file_name
         try:
-            # the override schema handles the 'US' location (the only location
-            # that doesn't parse as Int64)
-            # todo hard-coded column names
-            if target_data_file_path.suffix == '.csv':
+            if target_data_file_path.suffix == ".csv":
                 return pl.read_csv(
                     target_data_file_path,
                     schema_overrides={
-                        'location': pl.String,
-                        'value': pl.Float64,
-                        'observation': pl.Float64},
-                    null_values=["NA"]
+                        "location": pl.String,
+                        "value": pl.Float64,
+                        "observation": pl.Float64,
+                    },
+                    null_values=["NA"],
                 )
-            elif target_data_file_path.suffix == '.parquet':
+            elif target_data_file_path.suffix == ".parquet":
                 return pl.read_parquet(target_data_file_path)
             else:
                 raise ValueError(

--- a/src/hub_predtimechart/hub_config_ptc.py
+++ b/src/hub_predtimechart/hub_config_ptc.py
@@ -148,7 +148,9 @@ class HubConfigPtc(HubConnection):
                 f"Unsupported target data file format: {target_data_file_path.suffix}. "
                 f"Only .csv and .parquet are supported."
             )
-
+        # the override schema handles the 'US' location (the only location 
+        # that doesn't parse as Int64)
+        # todo hard-coded column names
         try:
             if target_data_file_path.suffix == ".csv":
                 return pl.read_csv(


### PR DESCRIPTION
This PR permits hub target data to be formatted as `.parquet` files (originally, only `.csv` files were supported, for the dashboard). The intention is to allow for the dashboard (<https://reichlab.io/covidhub-dashboard/forecast.html>) to support reading target-data from hubs that have `./target-data/time-series.parquet`. This repository `hub-dashboard-predtimechart` uses `get_target_data_df()` for reading target-data. This repository generates visualization data to a JSON file which is used by `predtimechart`. 

Tagging @dylanmorris for review.

I have personally not looked much into `predtimechart`, so there may be things I am missing.